### PR TITLE
Fix #37: consistent exemption-laws dropdowns across property pages

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -158,12 +158,7 @@ fields:
   - Specific laws that allow exemption: prop.interests[i].exemption_laws
     choices:
       code: |
-        # Use a static union of NE and SD real property exemptions to avoid
-        # triggering lookups of undefined variables during page render
-        list(dict.fromkeys(
-          get_exemption_choices('Nebraska', 'real_property') +
-          get_exemption_choices('South Dakota', 'real_property')
-        ))
+        get_exemption_choices_combined('real_property')
     show if: prop.interests[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.interests[i].is_claiming_exemption
@@ -294,12 +289,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_vehicles[i].exemption_laws
     choices:
       code: |
-        # Use a static union of NE and SD vehicle exemptions to avoid
-        # triggering lookups of undefined variables during page render
-        list(dict.fromkeys(
-          get_exemption_choices('Nebraska', 'vehicle') +
-          get_exemption_choices('South Dakota', 'vehicle')
-        ))
+        get_exemption_choices_combined('vehicle')
     show if: prop.ab_vehicles[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.ab_vehicles[i].is_claiming_exemption
@@ -310,12 +300,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_vehicles[i].exemption_laws_2
     choices:
       code: |
-        # Use a static union of NE and SD vehicle exemptions to avoid
-        # triggering lookups of undefined variables during page render
-        list(dict.fromkeys(
-          get_exemption_choices('Nebraska', 'vehicle') +
-          get_exemption_choices('South Dakota', 'vehicle')
-        ))
+        get_exemption_choices_combined('vehicle')
     show if: prop.ab_vehicles[i].is_claiming_exemption
     required: False
 list collect: True
@@ -429,12 +414,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws
     choices:
       code: |
-        # Use a static union of NE and SD vehicle exemptions to avoid
-        # triggering lookups of undefined variables during page render
-        list(dict.fromkeys(
-          get_exemption_choices('Nebraska', 'vehicle') +
-          get_exemption_choices('South Dakota', 'vehicle')
-        ))
+        get_exemption_choices_combined('vehicle')
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - note: Exemption 2
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
@@ -445,12 +425,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws_2
     choices:
       code: |
-        # Use a static union of NE and SD vehicle exemptions to avoid
-        # triggering lookups of undefined variables during page render
-        list(dict.fromkeys(
-          get_exemption_choices('Nebraska', 'vehicle') +
-          get_exemption_choices('South Dakota', 'vehicle')
-        ))
+        get_exemption_choices_combined('vehicle')
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
     required: False
 list collect: True
@@ -586,7 +561,7 @@ fields:
   - Specific laws that allow exemption: prop.household_goods_exemption_laws
     choices:
       code: |
-        get_exemption_choices(debtor[0].address.state, 'all')
+        get_exemption_choices_combined('household_goods')
     show if: prop.household_goods_is_claiming_exemption
   - note: Exemption 2
     show if: prop.household_goods_is_claiming_exemption
@@ -597,7 +572,7 @@ fields:
   - Specific laws that allow exemption: prop.household_goods_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices(debtor[0].address.state, 'all')
+        get_exemption_choices_combined('household_goods')
     show if: prop.household_goods_is_claiming_exemption
     required: False
 
@@ -623,9 +598,8 @@ fields:
     show if: prop.secured_household_goods_claiming_sub_100
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws
     choices:
-      - Household goods (Neb. Rev. Stat. § 25-1556(1)(c))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('household_goods')
     show if: prop.secured_household_goods_is_claiming_exemption
   - note: Exemption 2
     show if: prop.secured_household_goods_is_claiming_exemption
@@ -635,9 +609,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws_2
     choices:
-      - Household goods (Neb. Rev. Stat. § 25-1556(1)(c))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('household_goods')
     show if: prop.secured_household_goods_is_claiming_exemption
     required: False
 
@@ -663,10 +636,8 @@ fields:
     show if: prop.electronics_claiming_sub_100
   - Specific laws that allow exemption: prop.electronics_exemption_laws
     choices:
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Household goods (Neb. Rev. Stat. § 25-1556(1)(c))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('electronics')
     show if: prop.electronics_is_claiming_exemption
   - note: Second Exemption
     show if: prop.electronics_is_claiming_exemption
@@ -676,10 +647,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.electronics_exemption_laws_2
     choices:
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Household goods (Neb. Rev. Stat. § 25-1556(1)(c))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('electronics')
     show if: prop.electronics_is_claiming_exemption
     required: False
 
@@ -705,8 +674,8 @@ fields:
     show if: prop.collectibles_claiming_sub_100
   - Specific laws that allow exemption: prop.collectibles_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.collectibles_is_claiming_exemption
   - note: Second Exemption
     show if: prop.collectibles_is_claiming_exemption
@@ -716,8 +685,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.collectibles_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.collectibles_is_claiming_exemption
     required: False
 
@@ -743,8 +712,8 @@ fields:
     show if: prop.hobby_equipment_claiming_sub_100
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.hobby_equipment_is_claiming_exemption
   - note: Second Exemption
     show if: prop.hobby_equipment_is_claiming_exemption
@@ -754,8 +723,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.hobby_equipment_is_claiming_exemption
     required: False
 
@@ -781,8 +750,8 @@ fields:
     show if: prop.firearms_claiming_sub_100
   - Specific laws that allow exemption: prop.firearms_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.firearms_is_claiming_exemption
   - note: Second Exemption
     show if: prop.firearms_is_claiming_exemption
@@ -792,8 +761,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.firearms_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.firearms_is_claiming_exemption
     required: False
 
@@ -819,9 +788,8 @@ fields:
     show if: prop.clothes_claiming_sub_100
   - Specific laws that allow exemption: prop.clothes_exemption_laws
     choices:
-      - Clothing (Neb. Rev. Stat. § 25-1556(1)(b))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('clothes')
     show if: prop.clothes_is_claiming_exemption
   - note: Second Exemption
     show if: prop.clothes_is_claiming_exemption
@@ -831,9 +799,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.clothes_exemption_laws_2
     choices:
-      - Clothing (Neb. Rev. Stat. § 25-1556(1)(b))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('clothes')
     show if: prop.clothes_is_claiming_exemption
     required: False
 
@@ -859,10 +826,8 @@ fields:
     show if: prop.jewelry_claiming_sub_100
   - Specific laws that allow exemption: prop.jewelry_exemption_laws
     choices:
-      - Clothing (Neb. Rev. Stat. § 25-1556(1)(b))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
-      - Immediate personal possessions (Neb. Rev. Stat. § 25-1556(1)(a))
+      code: |
+        get_exemption_choices_combined('jewelry')
     show if: prop.jewelry_is_claiming_exemption
   - note: Second Exemption
     show if: prop.jewelry_is_claiming_exemption
@@ -872,10 +837,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.jewelry_exemption_laws_2
     choices:
-      - Clothing (Neb. Rev. Stat. § 25-1556(1)(b))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
-      - Immediate personal possessions (Neb. Rev. Stat. § 25-1556(1)(a))
+      code: |
+        get_exemption_choices_combined('jewelry')
     show if: prop.jewelry_is_claiming_exemption
     required: False
 
@@ -901,8 +864,8 @@ fields:
     show if: prop.animal_claiming_sub_100
   - Specific laws that allow exemption: prop.animal_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.animal_is_claiming_exemption
   - note: Second Exemption
     show if: prop.animal_is_claiming_exemption
@@ -912,8 +875,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.animal_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.animal_is_claiming_exemption
     required: False
 
@@ -939,9 +902,8 @@ fields:
     show if: prop.other_household_items_claiming_sub_100
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws
     choices:
-      - Health Aids (Neb. Rev. Stat. § 25-1556(1)(f))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('other_household_items')
     show if: prop.other_household_items_is_claiming_exemption
   - note: Second Exemption
     show if: prop.other_household_items_is_claiming_exemption
@@ -951,9 +913,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws_2
     choices:
-      - Health Aids (Neb. Rev. Stat. § 25-1556(1)(f))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('other_household_items')
     show if: prop.other_household_items_is_claiming_exemption
     required: False
 
@@ -1003,9 +964,8 @@ fields:
     show if: prop.financial_assets.cash_sub_100
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Public Benefits (Neb. Rev. Stat. § 68-148)
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('cash')
     show if: prop.financial_assets.cash_is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.cash_is_claiming_exemption
@@ -1015,9 +975,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Public Benefits (Neb. Rev. Stat. § 68-148)
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('cash')
     show if: prop.financial_assets.cash_is_claiming_exemption
     required: False
 ---
@@ -1096,8 +1055,8 @@ fields:
     show if: prop.financial_assets.deposits[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
@@ -1107,8 +1066,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
     required: False
 list collect: True
@@ -1180,8 +1139,8 @@ fields:
     show if: prop.financial_assets.bonds_and_stocks[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
@@ -1191,8 +1150,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
     required: False
 list collect: True 
@@ -1268,8 +1227,8 @@ fields:
     show if: prop.financial_assets.non_traded_stock[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
@@ -1279,8 +1238,8 @@ fields:
     required: false
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
     required: false
 list collect: True 
@@ -1352,8 +1311,8 @@ fields:
     show if: prop.financial_assets.corporate_bonds[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
@@ -1363,8 +1322,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
     required: False
 list collect: True
@@ -1447,11 +1406,8 @@ fields:
     show if: prop.financial_assets.retirement_accounts[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws
     choices:
-      - Retirement accounts (Neb. Rev. Stat. § 25-1563.01)
-      - Social Security (42 U.S.C. § 407)
-      - VA Benefits (38 U.S.C. § 5301(a))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('retirement')
     show if: prop.financial_assets.retirement_accounts[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.retirement_accounts[i].has_claim
@@ -1461,11 +1417,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws_2
     choices:
-      - Retirement accounts (Neb. Rev. Stat. § 25-1563.01)
-      - Social Security (42 U.S.C. § 407)
-      - VA Benefits (38 U.S.C. § 5301(a))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('retirement')
     show if: prop.financial_assets.retirement_accounts[i].has_claim
     required: False
 list collect: True
@@ -1551,8 +1504,8 @@ fields:
     show if: prop.financial_assets.prepayments[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.prepayments[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.prepayments[i].has_claim
@@ -1562,8 +1515,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.prepayments[i].has_claim
     required: False
 list collect: True
@@ -1636,9 +1589,8 @@ fields:
     show if: prop.financial_assets.annuities[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws
     choices:
-      - Wages (Neb. Rev. Stat. § 25-1558)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wages')
     show if: prop.financial_assets.annuities[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.annuities[i].has_claim
@@ -1648,9 +1600,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws_2
     choices:
-      - Wages (Neb. Rev. Stat. § 25-1558)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wages')
     show if: prop.financial_assets.annuities[i].has_claim
     required: False
 list collect: True
@@ -1723,9 +1674,8 @@ fields:
     show if: prop.financial_assets.edu_accounts[i].sub_100
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws
     choices:
-      - College Savings Plan (Neb. Rev. Stat. § 85-1809)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('edu_accounts')
     show if: prop.financial_assets.edu_accounts[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.edu_accounts[i].has_claim
@@ -1735,9 +1685,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws_2
     choices:
-      - College Savings Plan (Neb. Rev. Stat. § 85-1809)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('edu_accounts')
     show if: prop.financial_assets.edu_accounts[i].has_claim
     required: False
 list collect: True
@@ -1787,8 +1736,8 @@ fields:
     show if: prop.financial_assets.future_property_interest_sub_100
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.future_property_interest_has_claim
   - note: Second Exemption
     show if: prop.financial_assets.future_property_interest_has_claim
@@ -1798,8 +1747,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.future_property_interest_has_claim
     required: False
 ---
@@ -1850,8 +1799,8 @@ fields:
     show if: prop.financial_assets.ip_interest_sub_100
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.ip_interest_has_claim
   - note: Second Exemption
     show if: prop.financial_assets.ip_interest_has_claim
@@ -1861,8 +1810,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.ip_interest_has_claim
     required: False
 ---
@@ -1912,8 +1861,8 @@ fields:
     show if: prop.financial_assets.intangible_interest_sub_100
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.intangible_interest_has_claim
   - note: Second Exemption
     show if: prop.financial_assets.intangible_interest_has_claim
@@ -1923,8 +1872,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.financial_assets.intangible_interest_has_claim
     required: False
 ---
@@ -2074,9 +2023,8 @@ fields:
     datatype: currency
   - Specific laws that allow exemption: prop.owed_property.tax_refund_exemption_laws
     choices:
-      - Earned Income Tax Credit (Neb Rev Stat 25-1553)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('tax_refund')
     show if: prop.owed_property.tax_refund_has_claim
   - note: Second Exemption
     show if: prop.owed_property.tax_refund_has_claim
@@ -2086,9 +2034,8 @@ fields:
     show if: prop.owed_property.tax_refund_has_claim
   - Specific laws that allow exemption: prop.owed_property.tax_refund_exemption_laws_2
     choices:
-      - Earned Income Tax Credit (Neb Rev Stat 25-1553)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('tax_refund')
     show if: prop.owed_property.tax_refund_has_claim
     required: False
 
@@ -2134,9 +2081,8 @@ fields:
     show if: prop.owed_property.family_support_sub_100
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws
     choices:
-      - Wages (Neb. Rev. Stat. § 25-1558)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wages')
     show if: prop.owed_property.family_support_has_claim
   - note: Second Exemption
     show if: prop.owed_property.family_support_has_claim
@@ -2146,9 +2092,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws_2
     choices:
-      - Wages (Neb. Rev. Stat. § 25-1558)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wages')
     show if: prop.owed_property.family_support_has_claim
     required: False
 
@@ -2179,9 +2124,8 @@ fields:
     show if: prop.owed_property.other_amounts_sub_100
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws
     choices:
-      - Wages (Neb. Rev. Stat. § 25-1558)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wages')
     show if: prop.owed_property.other_amounts_has_claim
   - note: Second Exemption
     show if: prop.owed_property.other_amounts_has_claim
@@ -2191,9 +2135,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws_2
     choices:
-      - Wages (Neb. Rev. Stat. § 25-1558)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wages')
     show if: prop.owed_property.other_amounts_has_claim
     required: False
 
@@ -2228,10 +2171,8 @@ fields:
     show if: prop.owed_property.first_insurance_interest_sub_100
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws
     choices:
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Health Savings (Neb. Rev. Stat. § 8-1,131(2)(b))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('insurance')
     show if: prop.owed_property.first_insurance_interest_has_claim
   - note: Second Exemption
     show if: prop.owed_property.first_insurance_interest_has_claim
@@ -2241,10 +2182,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws_2
     choices:
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Health Savings (Neb. Rev. Stat. § 8-1,131(2)(b))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('insurance')
     show if: prop.owed_property.first_insurance_interest_has_claim
     required: False
 
@@ -2276,10 +2215,8 @@ fields:
     show if: prop.owed_property.second_insurance_interest_sub_100
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws
     choices:
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Health Savings (Neb. Rev. Stat. § 8-1,131(2)(b))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('insurance')
     show if: prop.owed_property.second_insurance_interest_has_claim
   - note: Second Exemption
     show if: prop.owed_property.second_insurance_interest_has_claim
@@ -2289,10 +2226,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws_2
     choices:
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Health Savings (Neb. Rev. Stat. § 8-1,131(2)(b))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('insurance')
     show if: prop.owed_property.second_insurance_interest_has_claim
     required: False
 
@@ -2324,10 +2259,8 @@ fields:
     show if: prop.owed_property.third_insurance_interest_sub_100
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws
     choices:
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Health Savings (Neb. Rev. Stat. § 8-1,131(2)(b))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('insurance')
     show if: prop.owed_property.third_insurance_interest_has_claim
   - note: Second Exemption
     show if: prop.owed_property.third_insurance_interest_has_claim
@@ -2337,10 +2270,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws_2
     choices:
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Health Savings (Neb. Rev. Stat. § 8-1,131(2)(b))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('insurance')
     show if: prop.owed_property.third_insurance_interest_has_claim
     required: False
 
@@ -2371,9 +2302,8 @@ fields:
     show if: prop.owed_property.trust_sub_100
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws
     choices:
-      - Structured settlement (Neb. Rev. Stat. § 25-1563.02)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('trust')
     show if: prop.owed_property.trust_has_claim
   - note: Second Exemption
     show if: prop.owed_property.trust_has_claim
@@ -2383,9 +2313,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws_2
     choices:
-      - Structured settlement (Neb. Rev. Stat. § 25-1563.02)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('trust')
     show if: prop.owed_property.trust_has_claim
     required: False
 
@@ -2416,10 +2345,8 @@ fields:
     show if: prop.owed_property.third_party_sub_100
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws
     choices:
-      - Structured settlement (Neb. Rev. Stat. § 25-1563.02)
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('third_party')
     show if: prop.owed_property.third_party_has_claim
   - note: Second Exemption
     show if: prop.owed_property.third_party_has_claim
@@ -2429,10 +2356,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws_2
     choices:
-      - Structured settlement (Neb. Rev. Stat. § 25-1563.02)
-      - Life insurance proceeds (Neb. Rev. Stat. § 44-371)
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('third_party')
     show if: prop.owed_property.third_party_has_claim
     required: False
 
@@ -2461,8 +2386,8 @@ fields:
     show if: prop.owed_property.contingent_claims_sub_100
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.owed_property.contingent_claims_has_claim
   - note: Second Exemption
     show if: prop.owed_property.contingent_claims_has_claim
@@ -2472,8 +2397,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.owed_property.contingent_claims_has_claim
     required: False
 
@@ -2503,8 +2428,8 @@ fields:
     show if: prop.owed_property.other_assets_sub_100
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.owed_property.other_assets_has_claim
   - note: Second Exemption
     show if: prop.owed_property.other_assets_has_claim
@@ -2514,8 +2439,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.owed_property.other_assets_has_claim
     required: False
 ---
@@ -2635,9 +2560,8 @@ fields:
     show if: prop.business_property.ar_sub_100
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.ar_has_claim
   - note: Second Exemption
     show if: prop.business_property.ar_has_claim
@@ -2647,9 +2571,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.ar_has_claim
     required: False
 
@@ -2680,9 +2603,8 @@ fields:
     show if: prop.business_property.equipment_sub_100
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws
     choices:
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_equipment')
     show if: prop.business_property.equipment_has_claim
   - note: Second Exemption
     show if: prop.business_property.equipment_has_claim
@@ -2692,9 +2614,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws_2
     choices:
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_equipment')
     show if: prop.business_property.equipment_has_claim
     required: False
 
@@ -2724,9 +2645,8 @@ fields:
     show if: prop.business_property.machinery_sub_100
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws
     choices:
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_equipment')
     show if: prop.business_property.machinery_has_claim
   - note: Second Exemption
     show if: prop.business_property.machinery_has_claim
@@ -2736,9 +2656,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws_2
     choices:
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_equipment')
     show if: prop.business_property.machinery_has_claim
     required: False
 
@@ -2767,9 +2686,8 @@ fields:
     show if: prop.business_property.inventory_sub_100
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.inventory_has_claim
   - note: Second Exemption
     show if: prop.business_property.inventory_has_claim
@@ -2779,9 +2697,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.inventory_has_claim
     required: False
 
@@ -2858,9 +2775,8 @@ fields:
     show if: prop.business_property.partnership_sub_100
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.partnership_has_claim
   - note: Second Exemption
     show if: prop.business_property.partnership_has_claim
@@ -2870,9 +2786,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.partnership_has_claim
     required: False
 
@@ -2905,9 +2820,8 @@ fields:
     show if: prop.business_property.lists_sub_100
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.lists_has_claim
   - note: Second Exemption
     show if: prop.business_property.lists_has_claim
@@ -2917,9 +2831,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.lists_has_claim
     required: False
 
@@ -2983,9 +2896,8 @@ fields:
     show if: prop.business_property.otherProperty_sub_100
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.otherProperty_has_claim
   - note: Second Exemption
     show if: prop.business_property.otherProperty_has_claim
@@ -2995,9 +2907,8 @@ fields:
     show if: prop.business_property.otherProperty_sub_100
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('business_other')
     show if: prop.business_property.otherProperty_has_claim
     required: False
 
@@ -3098,8 +3009,8 @@ fields:
     show if: prop.farming_property.animal_sub_100
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_animal_claim
   - note: Second Exemption
     show if: prop.farming_property.has_animal_claim
@@ -3109,8 +3020,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_animal_claim
     required: False
 
@@ -3139,8 +3050,8 @@ fields:
     show if: prop.farming_property.crops_sub_100
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_crops_claim
   - note: Second Exemption
     show if: prop.farming_property.has_crops_claim
@@ -3150,8 +3061,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_crops_claim
     required: False
 
@@ -3179,8 +3090,8 @@ fields:
     show if: prop.farming_property.equipment_sub_100
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_equipment_claim
   - note: Second Exemption
     show if: prop.farming_property.has_equipment_claim
@@ -3190,8 +3101,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_equipment_claim
     required: False
 
@@ -3219,8 +3130,8 @@ fields:
     show if: prop.farming_property.supplies_sub_100
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_supplies_claim
   - note: Second Exemption
     show if: prop.farming_property.has_supplies_claim
@@ -3230,8 +3141,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_supplies_claim
     required: False
 
@@ -3260,8 +3171,8 @@ fields:
     show if: prop.farming_property.fishing_sub_100
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_fishing_claim
   - note: Second Exemption
     show if: prop.farming_property.has_fishing_claim
@@ -3271,8 +3182,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.farming_property.has_fishing_claim
     required: False
 
@@ -3341,8 +3252,8 @@ fields:
     show if: prop.other_prop_sub_100
   - Specific laws that allow exemption: prop.other_prop_exemption_laws
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.other_prop_has_claim
   - note: Second Exemption
     show if: prop.other_prop_has_claim
@@ -3352,8 +3263,8 @@ fields:
     required: False
   - Specific laws that allow exemption: prop.other_prop_exemption_laws_2
     choices:
-      - Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))
-      - Unknown law
+      code: |
+        get_exemption_choices_combined('wildcard_only')
     show if: prop.other_prop_has_claim
     required: False
 ---

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -1,105 +1,148 @@
 from docassemble.base.util import DAObject, Individual
 
 # State-specific exemption laws
+SOUTH_DAKOTA_EXEMPTIONS = {
+    'homestead': 'Homestead (SDCL 43-31-1 – 43-31-6)',
+    'homestead_proceeds': 'Homestead, proceeds of sale (SDCL 43-31-4)',
+    'household_goods': 'Furniture and bedding (SDCL 43-45-5(5))',
+    'wildcard': 'Wildcard (SDCL 43-5-4)',
+    'personal_property': 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)',
+    'domestic_support': 'Alimony, maintenance, or support of the debtor (SDCL 43-45-2)',
+    'health_aids': 'Health aids (SDCL 43-45-2)',
+    'tools': 'Tools of the trade (SDCL 43-45-5(6))',
+    'city_employee_pensions': 'City employee pensions (SDCL 9-16-47)',
+    'public_employee_pensions': 'Public employee pensions (SDCL 3-12-115)',
+    'retirement': 'Retirement (SDCL 43-45-26)',
+    'public_assistance': 'Public assistance (SDCL 28-7-16)',
+    'wages': 'Wages (SDCL 15-20-12)',
+    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4. 43-45-6)',
+    'workers_comp': 'Workers compensation (SDCL 62-4-42)',
+    'unemployment': 'Unemployment (SDCL 61-6-28)',
+    'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
+    'social_security': 'Social Security (42 U.S.C. § 407)',
+    'va': 'VA Benefits (38 U.S.C. § 5301(a))',
+    'unknown': 'Unknown law',
+}
+
+NEBRASKA_EXEMPTIONS = {
+    'homestead': 'Homestead (Neb. Rev. Stat. §§ 40-101 - 40-118)',
+    'homestead_proceeds': 'Homestead, proceeds of sale (Neb. Rev. Stat. § 40-116)',
+    'motor_vehicle': 'Motor vehicle (Neb. Rev. Stat. § 25-1556(1)(e))',
+    'household_goods': 'Household goods (Neb. Rev. Stat. § 25-1556(1)(c))',
+    'tools': 'Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))',
+    'clothing': 'Clothing (Neb. Rev. Stat. § 25-1556(1)(b))',
+    'personal_possessions': 'Immediate personal possessions (Neb. Rev. Stat. § 25-1556(1)(a))',
+    'health_aids': 'Health aids (Neb. Rev. Stat. § 25-1556(1)(f))',
+    'health_savings': 'Health savings (Neb. Rev. Stat. § 8-1,131(2)(b))',
+    'retirement': 'Retirement accounts (Neb. Rev. Stat. § 25-1563.01)',
+    'wages': 'Wages (Neb. Rev. Stat. § 25-1558)',
+    'public_benefits': 'Public benefits (Neb. Rev. Stat. § 68-148)',
+    'earned_income': 'Earned Income Tax Credit (Neb Rev Stat 25-1553)',
+    'life_insurance': 'Life insurance proceeds (Neb. Rev. Stat. § 44-371)',
+    'structured_settlement': 'Structured settlement (Neb. Rev. Stat. § 25-1563.02)',
+    'workers_comp': 'Workers compensation (Neb. Rev. Stat. § 48-149)',
+    'unemployment': 'Unemployment (Neb. Rev. Stat. § 48-647)',
+    'college_savings': 'College Savings Plan (Neb. Rev. Stat. § 85-1809)',
+    'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
+    'social_security': 'Social Security (42 U.S.C. § 407)',
+    'va': 'VA Benefits (38 U.S.C. § 5301(a))',
+    'wildcard': 'Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))',
+    'unknown': 'Unknown law',
+}
+
+# Per-property-type list of exemption keys to surface in the dropdown.
+# Keys absent from a state's dict are skipped, so the same category can be
+# resolved for any supported state.
+CATEGORY_KEYS = {
+    'real_property':            ['homestead', 'homestead_proceeds', 'wildcard', 'unknown'],
+    'vehicle':                  ['motor_vehicle', 'wildcard', 'unknown'],
+    'household_goods':          ['household_goods', 'wildcard', 'unknown'],
+    'electronics':              ['tools', 'household_goods', 'wildcard', 'unknown'],
+    'collectibles':             ['wildcard', 'unknown'],
+    'hobby_equipment':          ['wildcard', 'unknown'],
+    'firearms':                 ['wildcard', 'unknown'],
+    'clothes':                  ['clothing', 'personal_property', 'wildcard', 'unknown'],
+    'jewelry':                  ['clothing', 'personal_possessions', 'personal_property', 'wildcard', 'unknown'],
+    'animal':                   ['wildcard', 'unknown'],
+    'other_household_items':    ['health_aids', 'wildcard', 'unknown'],
+    'cash':                     ['wildcard', 'public_benefits', 'public_assistance', 'unknown'],
+    'deposits':                 ['wildcard', 'unknown'],
+    'bonds_stocks':             ['wildcard', 'unknown'],
+    'non_traded_stock':         ['wildcard', 'unknown'],
+    'corporate_bonds':          ['wildcard', 'unknown'],
+    'retirement':               ['retirement', 'social_security', 'va', 'wildcard',
+                                 'city_employee_pensions', 'public_employee_pensions', 'unknown'],
+    'prepayments':              ['wildcard', 'unknown'],
+    'wages':                    ['wages', 'wildcard', 'unknown'],
+    'wildcard_only':            ['wildcard', 'unknown'],
+    'edu_accounts':             ['college_savings', 'wildcard', 'unknown'],
+    'tax_refund':               ['earned_income', 'wildcard', 'unknown'],
+    'insurance':                ['life_insurance', 'wildcard', 'health_savings', 'unknown'],
+    'trust':                    ['structured_settlement', 'wildcard', 'unknown'],
+    'third_party':              ['structured_settlement', 'life_insurance', 'wildcard', 'unknown'],
+    'contingent_claims':        ['wildcard', 'unknown'],
+    'other_assets':             ['wildcard', 'unknown'],
+    'future_property_interest': ['wildcard', 'unknown'],
+    'ip':                       ['wildcard', 'unknown'],
+    'intangible':               ['wildcard', 'unknown'],
+    'business_ar':              ['wildcard', 'tools', 'unknown'],
+    'business_equipment':       ['tools', 'wildcard', 'unknown'],
+    'business_machinery':       ['tools', 'wildcard', 'unknown'],
+    'business_inventory':       ['wildcard', 'tools', 'unknown'],
+    'business_partnership':     ['wildcard', 'tools', 'unknown'],
+    'business_lists':           ['wildcard', 'tools', 'unknown'],
+    'business_other':           ['wildcard', 'tools', 'unknown'],
+    'farming_animal':           ['wildcard', 'unknown'],
+    'farming_crops':            ['wildcard', 'unknown'],
+    'farming_equipment':        ['tools', 'wildcard', 'unknown'],
+    'farming_supplies':         ['wildcard', 'unknown'],
+    'farming_fishing':          ['wildcard', 'unknown'],
+    'other_prop':               ['wildcard', 'unknown'],
+}
+
+# States supported by get_exemption_choices_combined(); keep in sync with
+# the per-state exemption dicts above.
+SUPPORTED_STATES = ('Nebraska', 'South Dakota')
+
+
 def get_exemption_choices(user_state, property_type='all'):
     """
     Returns a list of exemption law choices based on the user's state and property type.
-    
+
     Args:
         user_state (str): The user's state (e.g., "Nebraska", "South Dakota")
-        property_type (str): Type of property - 'real_property', 'vehicle', or 'all'
-    
+        property_type (str): Property category key (see CATEGORY_KEYS) or 'all'.
+
     Returns:
-        list: List of exemption law strings
+        list: List of exemption law strings (state-specific).
     """
-    
-    # Handle case where user_state might be None or undefined
     try:
         state_str = str(user_state).lower() if user_state else ''
     except Exception:
         state_str = ''
 
-    # South Dakota exemptions
-    south_dakota_exemptions = {
-        'homestead': 'Homestead (SDCL 43-31-1 – 43-31-6)',
-        'homestead_proceeds': 'Homestead, proceeds of sale (SDCL 43-31-4)',
-        'household_goods': 'Furniture and bedding (SDCL 43-45-5(5))',
-        'wildcard': 'Wildcard (SDCL 43-5-4)',
-        'personal_property': 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)',
-        'domestic_support': 'Alimony, maintenance, or support of the debtor (SDCL 43-45-2)',
-        'health_aids': 'Health aids (SDCL 43-45-2)',
-        'tools': 'Tools of the trade (SDCL 43-45-5(6))',
-        'city_employee_pensions': 'City employee pensions (SDCL 9-16-47)',
-        'public_employee_pensions': 'Public employee pensions (SDCL 3-12-115)',
-        'retirement': 'Retirement (SDCL 43-45-26)',
-        'public_assistance': 'Public assistance (SDCL 28-7-16)',
-        'wages': 'Wages (SDCL 15-20-12)',
-        'life_insurance': 'Life insurance proceeds (SDCL 58-12-4. 43-45-6)',
-        'workers_comp': 'Workers compensation (SDCL 62-4-42)',
-        'unemployment': 'Unemployment (SDCL 61-6-28)',
-        'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
-        'social_security': 'Social Security (42 U.S.C. § 407)',
-        'va': 'VA Benefits (38 U.S.C. § 5301(a))',
-        'unknown': 'Unknown law'
-    }
-    
-    # Nebraska exemptions  
-    nebraska_exemptions = {
-        'homestead': 'Homestead (Neb. Rev. Stat. §§ 40-101 - 40-118)',
-        'homestead_proceeds': 'Homestead, proceeds of sale (Neb. Rev. Stat. § 40-116)',
-        'motor_vehicle': 'Motor vehicle (Neb. Rev. Stat. § 25-1556(1)(e))',
-        'household_goods': 'Household goods (Neb. Rev. Stat. § 25-1556(1)(c))',
-        'tools': 'Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))',
-        'clothing': 'Clothing (Neb. Rev. Stat. § 25-1556(1)(b))',
-        'personal_possessions': 'Immediate personal possessions (Neb. Rev. Stat. § 25-1556(1)(a))',
-        'health_aids': 'Health aids (Neb. Rev. Stat. § 25-1556(1)(f))',
-        'health_savings': 'Health savings (Neb. Rev. Stat. § 8-1,131(2)(b))',
-        'retirement': 'Retirement accounts (Neb. Rev. Stat. § 25-1563.01)',
-        'wages': 'Wages (Neb. Rev. Stat. § 25-1558)',
-        'public_benefits': 'Public benefits (Neb. Rev. Stat. § 68-148)',
-        'earned_income': 'Earned Income Tax Credit (Neb Rev Stat 25-1553)',
-        'life_insurance': 'Life insurance proceeds (Neb. Rev. Stat. § 44-371)',
-        'structured_settlement': 'Structured settlement (Neb. Rev. Stat. § 25-1563.02)',
-        'workers_comp': 'Workers compensation (Neb. Rev. Stat. § 48-149)',
-        'unemployment': 'Unemployment (Neb. Rev. Stat. § 48-647)',
-        'college_savings': 'College Savings Plan (Neb. Rev. Stat. § 85-1809)',
-        'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
-        'social_security': 'Social Security (42 U.S.C. § 407)',
-        'va': 'VA Benefits (38 U.S.C. § 5301(a))',
-        'wildcard': 'Wildcard (Neb. Rev. Stat. § 25-1552(1)(c))',
-        'unknown': 'Unknown law'
-    }
-    # Determine which exemption set to use
-    if 'south dakota' in state_str:
-        exemptions = south_dakota_exemptions
-    else:
-        exemptions = nebraska_exemptions
-    
-    # Filter based on property type
-    if property_type == 'real_property':
-        choices = [
-            exemptions['homestead'],
-            exemptions['homestead_proceeds'],
-            exemptions['wildcard'],
-            exemptions['unknown']
-        ]
-    elif property_type == 'vehicle':
-        if 'south dakota' in state_str:
-            choices = [
-                exemptions['wildcard'],
-                exemptions['unknown']
-            ]
-        else:
-            choices = [
-                exemptions['motor_vehicle'],
-                exemptions['wildcard'],
-                exemptions['unknown']
-            ]
-    else:
-        # Return all exemptions for general property
-        choices = list(exemptions.values())
-    
-    return choices
+    exemptions = SOUTH_DAKOTA_EXEMPTIONS if 'south dakota' in state_str else NEBRASKA_EXEMPTIONS
+
+    if property_type == 'all':
+        return list(exemptions.values())
+
+    keys = CATEGORY_KEYS.get(property_type, [])
+    return [exemptions[k] for k in keys if k in exemptions]
+
+
+def get_exemption_choices_combined(property_type='all'):
+    """
+    Returns the de-duplicated union of every supported state's exemption law
+    choices for the given property category. Use this in interview YAML so the
+    dropdown is consistent across pages and does not depend on whether the
+    debtor's address has been entered yet.
+    """
+    seen = []
+    for state in SUPPORTED_STATES:
+        for law in get_exemption_choices(state, property_type):
+            if law not in seen:
+                seen.append(law)
+    return seen
 
 def get_exemption_limits(user_state):
     """
@@ -173,61 +216,14 @@ def compute_exemption_totals(prop, debtor_state):
         dict: {law_string: {'claimed': total_claimed, 'limit': limit_value, 'remaining': remaining}}
     """
     limits = get_exemption_limits(debtor_state)
-    law_choices = get_exemption_choices(debtor_state, 'all')
 
-    # Map law strings to category keys for limit lookups
+    # Map every supported state's law string -> category key. The user can pick
+    # any state's law from the unified dropdowns, so the tracker has to recognize
+    # all of them; limits are still looked up using the debtor's own state.
     law_to_category = {}
-    if 'south dakota' in str(debtor_state).lower():
-        sd_exemptions = {
-            'homestead': 'Homestead (SDCL 43-31-1',
-            'homestead_proceeds': 'Homestead, proceeds',
-            'household_goods': 'Furniture and bedding',
-            'wildcard': 'Wildcard',
-            'personal_property': 'Bible, books',
-            'health_aids': 'Health aids',
-            'tools': 'Tools of the trade',
-            'retirement': 'Retirement',
-            'wages': 'Wages',
-            'life_insurance': 'Life insurance',
-            'workers_comp': 'Workers compensation',
-            'unemployment': 'Unemployment',
-            'social_security': 'Social Security',
-            'va': 'VA Benefits',
-        }
-        for cat, prefix in sd_exemptions.items():
-            for law_str in law_choices:
-                if law_str.startswith(prefix):
-                    law_to_category[law_str] = cat
-                    break
-    else:
-        ne_exemptions = {
-            'homestead': 'Homestead (Neb. Rev. Stat. §§ 40-101',
-            'homestead_proceeds': 'Homestead, proceeds',
-            'motor_vehicle': 'Motor vehicle',
-            'household_goods': 'Household goods',
-            'wildcard': 'Wildcard',
-            'clothing': 'Clothing',
-            'personal_possessions': 'Immediate personal possessions',
-            'health_aids': 'Health aids',
-            'health_savings': 'Health savings',
-            'tools': 'Tools of the trade',
-            'retirement': 'Retirement',
-            'wages': 'Wages',
-            'public_benefits': 'Public benefits',
-            'earned_income': 'Earned Income',
-            'life_insurance': 'Life insurance',
-            'structured_settlement': 'Structured settlement',
-            'workers_comp': 'Workers compensation',
-            'unemployment': 'Unemployment',
-            'college_savings': 'College Savings',
-            'social_security': 'Social Security',
-            'va': 'VA Benefits',
-        }
-        for cat, prefix in ne_exemptions.items():
-            for law_str in law_choices:
-                if law_str.startswith(prefix):
-                    law_to_category[law_str] = cat
-                    break
+    for _state_dict in (NEBRASKA_EXEMPTIONS, SOUTH_DAKOTA_EXEMPTIONS):
+        for cat, law in _state_dict.items():
+            law_to_category[law] = cat
 
     # Accumulate claimed amounts per law string
     claimed_by_law = {}

--- a/tests/exemption-consistency.spec.ts
+++ b/tests/exemption-consistency.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression guard for issue #37 — exemption-list inconsistency.
+ *
+ * Background: 106AB-question-blocks.yml previously had ~50 `choices:` blocks
+ * that listed Nebraska law citations as YAML literals, which meant the SD
+ * variants were missing on those pages while real-property/vehicle pages did
+ * show both. Customer reported "sometimes SD exemptions are offered, sometimes
+ * not." The fix routes every choice list through `get_exemption_choices_combined()`
+ * in objects.py.
+ *
+ * This test reads the YAML from disk and asserts no hardcoded statute citation
+ * appears under any `choices:` block — so any future regression that re-introduces
+ * a static NE-only list will fail here instead of in production.
+ */
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const QUESTIONS = [
+  '106AB-question-blocks.yml',
+  '106C-question-blocks.yml',
+  '106D-question-blocks.yml',
+];
+
+const STATUTE_PATTERNS = [
+  /Neb\.\s*Rev\.\s*Stat\./i,
+  /\bSDCL\s+\d/i,
+  /\bU\.S\.C\.\s*§/i,
+];
+
+test.describe('Exemption list consistency (issue #37)', () => {
+  for (const file of QUESTIONS) {
+    test(`${file} contains no hardcoded statute citations under choices:`, () => {
+      const path = join(
+        __dirname,
+        '..',
+        'docassemble',
+        'BankruptcyClinic',
+        'data',
+        'questions',
+        file,
+      );
+      const text = readFileSync(path, 'utf8');
+      const lines = text.split('\n');
+
+      // Walk top-down and track whether the next list of `- ` items belongs
+      // to a `choices:` literal block. We flag a hardcoded statute only when
+      // it appears as a YAML list item under `choices:` (not under `code:`).
+      const offenders: Array<{ lineNo: number; line: string }> = [];
+      let inChoicesLiteral = false;
+      let choicesIndent = -1;
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const stripped = line.trimEnd();
+
+        const choicesMatch = stripped.match(/^(\s*)choices:\s*$/);
+        if (choicesMatch) {
+          // Look ahead — if the next non-blank line is `code:` then this is a
+          // computed choices block (the fix), not a literal list.
+          let j = i + 1;
+          while (j < lines.length && lines[j].trim() === '') j++;
+          const next = lines[j] || '';
+          if (/^\s*code:\s*[|>]?\s*$/.test(next)) {
+            inChoicesLiteral = false;
+          } else {
+            inChoicesLiteral = true;
+            choicesIndent = choicesMatch[1].length;
+          }
+          continue;
+        }
+
+        if (!inChoicesLiteral) continue;
+
+        // Exit the literal block when indentation drops back to or below the
+        // `choices:` key, or when we hit a different field key.
+        const leading = line.match(/^(\s*)/)?.[1].length ?? 0;
+        const isListItem = /^\s*-\s/.test(line);
+        if (line.trim() !== '' && !isListItem && leading <= choicesIndent) {
+          inChoicesLiteral = false;
+          continue;
+        }
+
+        if (isListItem && STATUTE_PATTERNS.some((re) => re.test(line))) {
+          offenders.push({ lineNo: i + 1, line: stripped });
+        }
+      }
+
+      if (offenders.length > 0) {
+        const sample = offenders
+          .slice(0, 5)
+          .map((o) => `  L${o.lineNo}: ${o.line}`)
+          .join('\n');
+        throw new Error(
+          `${file}: ${offenders.length} hardcoded statute citation(s) found ` +
+            `under choices: blocks. Replace with ` +
+            `\`code: get_exemption_choices_combined('<category>')\` so both NE ` +
+            `and SD options surface consistently.\n${sample}`,
+        );
+      }
+      expect(offenders.length).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes #37 (the inconsistency where SD exemption laws appeared on real-property and vehicle pages but not on household-goods, electronics, retirement, business, etc.)
- Replaces 95 inconsistent `choices:` blocks in `106AB-question-blocks.yml` with a single uniform `code: get_exemption_choices_combined('<category>')` pattern
- Extends `objects.py` with a per-category exemption-key map and a `get_exemption_choices_combined()` helper that returns the de-duplicated NE + SD union (and doesn't depend on the debtor's address being entered, which was the root cause of one of the three pre-existing patterns)

**Citation text is unchanged.** Every law string in the dropdowns now sources from the same per-state dicts in `objects.py` that were already there. A separate attorney review of the citations themselves is being requested by email.

## Root cause

Schedule A/B previously had three different patterns for building exemption-laws dropdowns:

1. Real property + vehicles + other vehicles → static union of NE and SD via two `get_exemption_choices()` calls
2. Regular household goods → `get_exemption_choices(debtor[0].address.state, 'all')` (state-conditional, returned full list for the debtor's state only)
3. ~47 other dropdowns (electronics, clothes, jewelry, retirement, cash, business, farming, etc.) → hardcoded NE-only YAML literals, no SD options at all

A debtor filing in Nebraska would see SD law citations on patterns (1) and nowhere else. That matches the customer's report of "sometimes SD, sometimes not, and some pages have a long list while others have a short one."

## What changed

**`docassemble/BankruptcyClinic/objects.py`:**
- Promoted the per-state exemption dicts to module-level constants (`NEBRASKA_EXEMPTIONS`, `SOUTH_DAKOTA_EXEMPTIONS`).
- Added a `CATEGORY_KEYS` map covering every property category referenced in the YAML (real property, vehicle, household goods, electronics, jewelry, retirement, insurance, wages, business equipment, farming, etc.).
- Reworked `get_exemption_choices(state, category)` to look up the category's keys in the state's dict — back-compatible with the existing `'real_property'`, `'vehicle'`, and `'all'` callers.
- Added `get_exemption_choices_combined(category)` that returns the de-duplicated NE + SD union for a given category.
- Simplified `compute_exemption_totals` to build its `law_to_category` map from both states' dicts (so the tracker recognizes any law a user might pick from the unified dropdown).

**`docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml`:**
- Replaced all 95 `choices:` blocks for exemption-laws fields with `code: get_exemption_choices_combined('<category>')`. Each property type maps to the appropriate logical category (e.g., the electronics fields use `'electronics'`, the family-support fields use `'wages'`, etc.).

**New: `tests/exemption-consistency.spec.ts`:**
- Static-analysis regression guard. Reads each Schedule A/B/C/D YAML file and asserts no hardcoded statute citation (`Neb. Rev. Stat.`, `SDCL`, `U.S.C.`) appears under any literal `choices:` list. Fails the build if anyone re-introduces a pattern (3) dropdown.

## Test plan

- [x] `npm run test:smoke` — 4/4 pass
- [x] `npx playwright test tests/exemption-consistency.spec.ts` — 3/3 pass (new regression guard)
- [x] `npx playwright test tests/scenario-simple-single.spec.ts --workers=1` — 1/1 pass (2.5 min, 19 PDFs verified)
- [ ] Optionally `npm run test:scenarios` and `npm run test:pdfs` for full coverage before merge

## Follow-up

The structural fix is independent of citation accuracy. An attorney review of the existing citation strings has been requested separately by email — any corrections that come back will be a one-touch update to `objects.py` (no further YAML changes needed, thanks to this consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)