### PR TITLE
Exemptions restricted to filing state + remove nonpriority gate

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -1,6 +1,20 @@
 modules:
   - docassemble.BankruptcyClinic.objects
-
+---
+code: |
+  # Filing state that restricts the exemption dropdowns (clinic decision: filing
+  # in Nebraska shows Nebraska exemptions, South Dakota shows SD). Derived from
+  # the chosen district, then the debtor's address; falls back to '' which makes
+  # get_exemption_choices_or_combined() show the combined NE+SD list.
+  if defined('current_district') and 'south dakota' in str(current_district).lower():
+    exemption_filing_state = 'South Dakota'
+  elif defined('current_district') and 'nebraska' in str(current_district).lower():
+    exemption_filing_state = 'Nebraska'
+  elif defined('debtor[0].address.state'):
+    exemption_filing_state = str(debtor[0].address.state)
+  else:
+    exemption_filing_state = ''
+---
 id: schedule_ab_property_intro
 event: property_intro
 section: schedule_ab
@@ -176,7 +190,7 @@ fields:
   - Specific laws that allow exemption: prop.interests[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('real_property')
+        get_exemption_choices_or_combined(exemption_filing_state,'real_property')
     show if: prop.interests[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.interests[i].is_claiming_exemption
@@ -187,10 +201,7 @@ fields:
   - Specific laws that allow exemption: prop.interests[i].exemption_laws_2
     choices:
       code: |
-        list(dict.fromkeys(
-          get_exemption_choices('Nebraska', 'real_property') +
-          get_exemption_choices('South Dakota', 'real_property')
-        ))
+        get_exemption_choices_or_combined(exemption_filing_state, 'real_property')
     show if: prop.interests[i].is_claiming_exemption
     required: False
 list collect: True
@@ -322,7 +333,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_vehicles[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('vehicle')
+        get_exemption_choices_or_combined(exemption_filing_state,'vehicle')
     show if: prop.ab_vehicles[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.ab_vehicles[i].is_claiming_exemption
@@ -333,7 +344,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_vehicles[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('vehicle')
+        get_exemption_choices_or_combined(exemption_filing_state,'vehicle')
     show if: prop.ab_vehicles[i].is_claiming_exemption
     required: False
 list collect: True
@@ -447,7 +458,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('vehicle')
+        get_exemption_choices_or_combined(exemption_filing_state,'vehicle')
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - note: Exemption 2
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
@@ -458,7 +469,7 @@ fields:
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('vehicle')
+        get_exemption_choices_or_combined(exemption_filing_state,'vehicle')
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
     required: False
 list collect: True
@@ -594,7 +605,7 @@ fields:
   - Specific laws that allow exemption: prop.household_goods_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('household_goods')
+        get_exemption_choices_or_combined(exemption_filing_state,'household_goods')
     show if: prop.household_goods_is_claiming_exemption
   - note: Exemption 2
     show if: prop.household_goods_is_claiming_exemption
@@ -605,7 +616,7 @@ fields:
   - Specific laws that allow exemption: prop.household_goods_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('household_goods')
+        get_exemption_choices_or_combined(exemption_filing_state,'household_goods')
     show if: prop.household_goods_is_claiming_exemption
     required: False
 
@@ -632,7 +643,7 @@ fields:
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('household_goods')
+        get_exemption_choices_or_combined(exemption_filing_state,'household_goods')
     show if: prop.secured_household_goods_is_claiming_exemption
   - note: Exemption 2
     show if: prop.secured_household_goods_is_claiming_exemption
@@ -643,7 +654,7 @@ fields:
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('household_goods')
+        get_exemption_choices_or_combined(exemption_filing_state,'household_goods')
     show if: prop.secured_household_goods_is_claiming_exemption
     required: False
 
@@ -670,7 +681,7 @@ fields:
   - Specific laws that allow exemption: prop.electronics_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('electronics')
+        get_exemption_choices_or_combined(exemption_filing_state,'electronics')
     show if: prop.electronics_is_claiming_exemption
   - note: Second Exemption
     show if: prop.electronics_is_claiming_exemption
@@ -681,7 +692,7 @@ fields:
   - Specific laws that allow exemption: prop.electronics_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('electronics')
+        get_exemption_choices_or_combined(exemption_filing_state,'electronics')
     show if: prop.electronics_is_claiming_exemption
     required: False
 
@@ -708,7 +719,7 @@ fields:
   - Specific laws that allow exemption: prop.collectibles_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.collectibles_is_claiming_exemption
   - note: Second Exemption
     show if: prop.collectibles_is_claiming_exemption
@@ -719,7 +730,7 @@ fields:
   - Specific laws that allow exemption: prop.collectibles_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.collectibles_is_claiming_exemption
     required: False
 
@@ -746,7 +757,7 @@ fields:
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.hobby_equipment_is_claiming_exemption
   - note: Second Exemption
     show if: prop.hobby_equipment_is_claiming_exemption
@@ -757,7 +768,7 @@ fields:
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.hobby_equipment_is_claiming_exemption
     required: False
 
@@ -784,7 +795,7 @@ fields:
   - Specific laws that allow exemption: prop.firearms_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.firearms_is_claiming_exemption
   - note: Second Exemption
     show if: prop.firearms_is_claiming_exemption
@@ -795,7 +806,7 @@ fields:
   - Specific laws that allow exemption: prop.firearms_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.firearms_is_claiming_exemption
     required: False
 
@@ -822,7 +833,7 @@ fields:
   - Specific laws that allow exemption: prop.clothes_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('clothes')
+        get_exemption_choices_or_combined(exemption_filing_state,'clothes')
     show if: prop.clothes_is_claiming_exemption
   - note: Second Exemption
     show if: prop.clothes_is_claiming_exemption
@@ -833,7 +844,7 @@ fields:
   - Specific laws that allow exemption: prop.clothes_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('clothes')
+        get_exemption_choices_or_combined(exemption_filing_state,'clothes')
     show if: prop.clothes_is_claiming_exemption
     required: False
 
@@ -860,7 +871,7 @@ fields:
   - Specific laws that allow exemption: prop.jewelry_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('jewelry')
+        get_exemption_choices_or_combined(exemption_filing_state,'jewelry')
     show if: prop.jewelry_is_claiming_exemption
   - note: Second Exemption
     show if: prop.jewelry_is_claiming_exemption
@@ -871,7 +882,7 @@ fields:
   - Specific laws that allow exemption: prop.jewelry_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('jewelry')
+        get_exemption_choices_or_combined(exemption_filing_state,'jewelry')
     show if: prop.jewelry_is_claiming_exemption
     required: False
 
@@ -898,7 +909,7 @@ fields:
   - Specific laws that allow exemption: prop.animal_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.animal_is_claiming_exemption
   - note: Second Exemption
     show if: prop.animal_is_claiming_exemption
@@ -909,7 +920,7 @@ fields:
   - Specific laws that allow exemption: prop.animal_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.animal_is_claiming_exemption
     required: False
 
@@ -936,7 +947,7 @@ fields:
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('other_household_items')
+        get_exemption_choices_or_combined(exemption_filing_state,'other_household_items')
     show if: prop.other_household_items_is_claiming_exemption
   - note: Second Exemption
     show if: prop.other_household_items_is_claiming_exemption
@@ -947,7 +958,7 @@ fields:
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('other_household_items')
+        get_exemption_choices_or_combined(exemption_filing_state,'other_household_items')
     show if: prop.other_household_items_is_claiming_exemption
     required: False
 
@@ -998,7 +1009,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('cash')
+        get_exemption_choices_or_combined(exemption_filing_state,'cash')
     show if: prop.financial_assets.cash_is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.cash_is_claiming_exemption
@@ -1009,7 +1020,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('cash')
+        get_exemption_choices_or_combined(exemption_filing_state,'cash')
     show if: prop.financial_assets.cash_is_claiming_exemption
     required: False
 ---
@@ -1089,7 +1100,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
@@ -1100,7 +1111,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
     required: False
 list collect: True
@@ -1173,7 +1184,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
@@ -1184,7 +1195,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
     required: False
 list collect: True 
@@ -1261,7 +1272,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
@@ -1272,7 +1283,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
     required: false
 list collect: True 
@@ -1345,7 +1356,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - note: Second Exemption
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
@@ -1356,7 +1367,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
     required: False
 list collect: True
@@ -1440,7 +1451,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('retirement')
+        get_exemption_choices_or_combined(exemption_filing_state,'retirement')
     show if: prop.financial_assets.retirement_accounts[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.retirement_accounts[i].has_claim
@@ -1451,7 +1462,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('retirement')
+        get_exemption_choices_or_combined(exemption_filing_state,'retirement')
     show if: prop.financial_assets.retirement_accounts[i].has_claim
     required: False
 list collect: True
@@ -1538,7 +1549,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.prepayments[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.prepayments[i].has_claim
@@ -1549,7 +1560,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.prepayments[i].has_claim
     required: False
 list collect: True
@@ -1623,7 +1634,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wages')
+        get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.financial_assets.annuities[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.annuities[i].has_claim
@@ -1634,7 +1645,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wages')
+        get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.financial_assets.annuities[i].has_claim
     required: False
 list collect: True
@@ -1708,7 +1719,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('edu_accounts')
+        get_exemption_choices_or_combined(exemption_filing_state,'edu_accounts')
     show if: prop.financial_assets.edu_accounts[i].has_claim
   - note: Second Exemption
     show if: prop.financial_assets.edu_accounts[i].has_claim
@@ -1719,7 +1730,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('edu_accounts')
+        get_exemption_choices_or_combined(exemption_filing_state,'edu_accounts')
     show if: prop.financial_assets.edu_accounts[i].has_claim
     required: False
 list collect: True
@@ -1771,7 +1782,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.future_property_interest_has_claim
   - note: Second Exemption
     show if: prop.financial_assets.future_property_interest_has_claim
@@ -1782,7 +1793,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.future_property_interest_has_claim
     required: False
 ---
@@ -1835,7 +1846,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.ip_interest_has_claim
   - note: Second Exemption
     show if: prop.financial_assets.ip_interest_has_claim
@@ -1846,7 +1857,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.ip_interest_has_claim
     required: False
 ---
@@ -1898,7 +1909,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.intangible_interest_has_claim
   - note: Second Exemption
     show if: prop.financial_assets.intangible_interest_has_claim
@@ -1909,7 +1920,7 @@ fields:
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.intangible_interest_has_claim
     required: False
 ---
@@ -2060,7 +2071,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.tax_refund_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('tax_refund')
+        get_exemption_choices_or_combined(exemption_filing_state,'tax_refund')
     show if: prop.owed_property.tax_refund_has_claim
   - note: Second Exemption
     show if: prop.owed_property.tax_refund_has_claim
@@ -2071,7 +2082,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.tax_refund_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('tax_refund')
+        get_exemption_choices_or_combined(exemption_filing_state,'tax_refund')
     show if: prop.owed_property.tax_refund_has_claim
     required: False
 
@@ -2118,7 +2129,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wages')
+        get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.owed_property.family_support_has_claim
   - note: Second Exemption
     show if: prop.owed_property.family_support_has_claim
@@ -2129,7 +2140,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wages')
+        get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.owed_property.family_support_has_claim
     required: False
 
@@ -2161,7 +2172,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wages')
+        get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.owed_property.other_amounts_has_claim
   - note: Second Exemption
     show if: prop.owed_property.other_amounts_has_claim
@@ -2172,7 +2183,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wages')
+        get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.owed_property.other_amounts_has_claim
     required: False
 
@@ -2208,7 +2219,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('insurance')
+        get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.first_insurance_interest_has_claim
   - note: Second Exemption
     show if: prop.owed_property.first_insurance_interest_has_claim
@@ -2219,7 +2230,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('insurance')
+        get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.first_insurance_interest_has_claim
     required: False
 
@@ -2252,7 +2263,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('insurance')
+        get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.second_insurance_interest_has_claim
   - note: Second Exemption
     show if: prop.owed_property.second_insurance_interest_has_claim
@@ -2263,7 +2274,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('insurance')
+        get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.second_insurance_interest_has_claim
     required: False
 
@@ -2296,7 +2307,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('insurance')
+        get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.third_insurance_interest_has_claim
   - note: Second Exemption
     show if: prop.owed_property.third_insurance_interest_has_claim
@@ -2307,7 +2318,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('insurance')
+        get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.third_insurance_interest_has_claim
     required: False
 
@@ -2340,7 +2351,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('trust')
+        get_exemption_choices_or_combined(exemption_filing_state,'trust')
     show if: prop.owed_property.trust_has_claim
   - note: Second Exemption
     show if: prop.owed_property.trust_has_claim
@@ -2351,7 +2362,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('trust')
+        get_exemption_choices_or_combined(exemption_filing_state,'trust')
     show if: prop.owed_property.trust_has_claim
     required: False
 
@@ -2384,7 +2395,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('third_party')
+        get_exemption_choices_or_combined(exemption_filing_state,'third_party')
     show if: prop.owed_property.third_party_has_claim
   - note: Second Exemption
     show if: prop.owed_property.third_party_has_claim
@@ -2395,7 +2406,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('third_party')
+        get_exemption_choices_or_combined(exemption_filing_state,'third_party')
     show if: prop.owed_property.third_party_has_claim
     required: False
 
@@ -2426,7 +2437,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('contingent_claims')
+        get_exemption_choices_or_combined(exemption_filing_state,'contingent_claims')
     show if: prop.owed_property.contingent_claims_has_claim
   - note: Second Exemption
     show if: prop.owed_property.contingent_claims_has_claim
@@ -2437,7 +2448,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('contingent_claims')
+        get_exemption_choices_or_combined(exemption_filing_state,'contingent_claims')
     show if: prop.owed_property.contingent_claims_has_claim
     required: False
 
@@ -2469,7 +2480,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.owed_property.other_assets_has_claim
   - note: Second Exemption
     show if: prop.owed_property.other_assets_has_claim
@@ -2480,7 +2491,7 @@ fields:
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.owed_property.other_assets_has_claim
     required: False
 ---
@@ -2601,7 +2612,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.ar_has_claim
   - note: Second Exemption
     show if: prop.business_property.ar_has_claim
@@ -2612,7 +2623,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.ar_has_claim
     required: False
 
@@ -2644,7 +2655,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_equipment')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_equipment')
     show if: prop.business_property.equipment_has_claim
   - note: Second Exemption
     show if: prop.business_property.equipment_has_claim
@@ -2655,7 +2666,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_equipment')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_equipment')
     show if: prop.business_property.equipment_has_claim
     required: False
 
@@ -2686,7 +2697,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_equipment')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_equipment')
     show if: prop.business_property.machinery_has_claim
   - note: Second Exemption
     show if: prop.business_property.machinery_has_claim
@@ -2697,7 +2708,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_equipment')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_equipment')
     show if: prop.business_property.machinery_has_claim
     required: False
 
@@ -2727,7 +2738,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.inventory_has_claim
   - note: Second Exemption
     show if: prop.business_property.inventory_has_claim
@@ -2738,7 +2749,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.inventory_has_claim
     required: False
 
@@ -2816,7 +2827,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.partnership_has_claim
   - note: Second Exemption
     show if: prop.business_property.partnership_has_claim
@@ -2827,7 +2838,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.partnership_has_claim
     required: False
 
@@ -2861,7 +2872,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.lists_has_claim
   - note: Second Exemption
     show if: prop.business_property.lists_has_claim
@@ -2872,7 +2883,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.lists_has_claim
     required: False
 
@@ -2937,7 +2948,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.otherProperty_has_claim
   - note: Second Exemption
     show if: prop.business_property.otherProperty_has_claim
@@ -2948,7 +2959,7 @@ fields:
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('business_other')
+        get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.otherProperty_has_claim
     required: False
 
@@ -3050,7 +3061,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_animal_claim
   - note: Second Exemption
     show if: prop.farming_property.has_animal_claim
@@ -3061,7 +3072,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_animal_claim
     required: False
 
@@ -3091,7 +3102,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_crops_claim
   - note: Second Exemption
     show if: prop.farming_property.has_crops_claim
@@ -3102,7 +3113,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_crops_claim
     required: False
 
@@ -3131,7 +3142,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_equipment_claim
   - note: Second Exemption
     show if: prop.farming_property.has_equipment_claim
@@ -3142,7 +3153,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_equipment_claim
     required: False
 
@@ -3171,7 +3182,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_supplies_claim
   - note: Second Exemption
     show if: prop.farming_property.has_supplies_claim
@@ -3182,7 +3193,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_supplies_claim
     required: False
 
@@ -3212,7 +3223,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_fishing_claim
   - note: Second Exemption
     show if: prop.farming_property.has_fishing_claim
@@ -3223,7 +3234,7 @@ fields:
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_fishing_claim
     required: False
 
@@ -3293,7 +3304,7 @@ fields:
   - Specific laws that allow exemption: prop.other_prop_exemption_laws
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.other_prop_has_claim
   - note: Second Exemption
     show if: prop.other_prop_has_claim
@@ -3304,7 +3315,7 @@ fields:
   - Specific laws that allow exemption: prop.other_prop_exemption_laws_2
     choices:
       code: |
-        get_exemption_choices_combined('wildcard_only')
+        get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.other_prop_has_claim
     required: False
 ---

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -441,6 +441,10 @@ code: |
   creditor_library_injected
   prop.creditors.gather()
   prop.priority_claims.gather()
+  # Skip the "do any creditors have nonpriority unsecured claims?" gate and go
+  # straight to the list (clinic decision — virtually every filer has at least
+  # one ordinary unsecured debt).
+  prop.nonpriority_claims.there_are_any = True
   prop.nonpriority_claims.gather()
   prop.contracts_and_leases.gather()
   codebtor_auto_populated

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -200,6 +200,21 @@ def get_exemption_choices_combined(property_type='all'):
                 seen.append(law)
     return seen
 
+
+def get_exemption_choices_or_combined(state, property_type='all'):
+    """
+    If `state` is one of the supported states, return ONLY that state's exemption
+    choices — filing in Nebraska shows Nebraska exemptions, filing in South
+    Dakota shows South Dakota exemptions (Roxanne feedback / clinic decision).
+    If `state` is empty/unknown (district not chosen yet), fall back to the
+    de-duplicated NE+SD union so the dropdown is never empty.
+    """
+    if state:
+        for s in SUPPORTED_STATES:
+            if s.lower() == str(state).lower():
+                return get_exemption_choices(s, property_type)
+    return get_exemption_choices_combined(property_type)
+
 def get_exemption_limits(user_state):
     """
     Returns a dict of exemption category -> dollar limit for the given state.

--- a/tests/exemption-runtime.spec.ts
+++ b/tests/exemption-runtime.spec.ts
@@ -1,14 +1,14 @@
 /**
- * Runtime regression test for issue #37.
+ * Runtime test for the exemption dropdowns.
  *
- * The static-analysis spec (exemption-consistency.spec.ts) proves no hardcoded
- * NE-only law lists remain in the YAML. This spec proves the fix actually
- * renders both NE and SD options in the dropdown when the page is loaded.
+ * Clinic decision (supersedes the original issue #37 "show both states"):
+ * exemptions are now restricted to the FILING STATE — a Nebraska filing shows
+ * Nebraska exemptions only, a South Dakota filing shows SD only.
  *
  * Walks a Nebraska debtor through intro → debtor → property → vehicles, lands
- * on the personal-and-household-items page (the page Lea reported as missing
- * SD options), claims an exemption on household goods, and asserts that the
- * exemption-laws dropdown contains both Nebraska and South Dakota citations.
+ * on the personal-and-household-items page, claims an exemption on household
+ * goods, and asserts the exemption-laws dropdown shows Nebraska citations and
+ * NOT South Dakota citations.
  */
 import { test, expect } from '@playwright/test';
 import { LEGACY_NE_MINIMAL } from './fixtures';
@@ -28,7 +28,7 @@ import {
 test.describe('Exemption dropdown runtime (issue #37)', () => {
   test.setTimeout(300_000);
 
-  test('household-goods exemption dropdown shows both NE and SD options', async ({ page }) => {
+  test('household-goods exemption dropdown is restricted to the filing state (NE only)', async ({ page }) => {
     const scenario = LEGACY_NE_MINIMAL;
 
     // intro → district → amendment → debtor identity
@@ -74,12 +74,12 @@ test.describe('Exemption dropdown runtime (issue #37)', () => {
     console.log(`  Dropdown options (${cleaned.length}):`);
     for (const o of cleaned) console.log(`    - ${o}`);
 
-    // The fix means this dropdown should contain both Nebraska and South
-    // Dakota law citations. Before the fix it was NE-only.
+    // Clinic decision: a Nebraska filing shows Nebraska citations and NOT
+    // South Dakota ones (exemptions restricted to the filing state).
     const hasNE = cleaned.some((o) => /Neb\.\s*Rev\.\s*Stat\./i.test(o));
     const hasSD = cleaned.some((o) => /\bSDCL\b/i.test(o));
 
-    expect(hasNE, 'expected at least one Nebraska citation in the dropdown').toBe(true);
-    expect(hasSD, 'expected at least one South Dakota citation in the dropdown — this is the regression Lea reported (#37)').toBe(true);
+    expect(hasNE, 'expected Nebraska citations in the dropdown for a NE filing').toBe(true);
+    expect(hasSD, 'expected NO South Dakota citations for a NE filing (exemptions restricted to filing state)').toBe(false);
   });
 });

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -737,39 +737,35 @@ export async function navigateUnsecuredCreditors(page: Page, scenario: TestScena
     await clickYesNoButton(page, 'prop.priority_claims.there_are_any', false);
   }
 
-  // Nonpriority claims
+  // Nonpriority claims — the "do any creditors have nonpriority unsecured
+  // claims?" gate was removed (clinic decision), so the interview goes straight
+  // to the first claim. Always fill one; use a default for scenarios that don't
+  // specify a nonpriority creditor.
   await waitForDaPageLoad(page);
-  if (scenario.creditors.nonpriority) {
-    await clickYesNoButton(page, 'prop.nonpriority_claims.there_are_any', true);
+  const np = scenario.creditors.nonpriority || {
+    name: 'General Unsecured Creditor', street: '1 Market St', city: 'Omaha',
+    state: 'Nebraska', zip: '68102', totalClaim: '1000', type: 'Credit Card',
+  };
+  await page.locator(`#${b64('prop.nonpriority_claims[0].name')}`).fill(np.name);
+  await page.locator(`#${b64('prop.nonpriority_claims[0].street')}`).fill(np.street);
+  await page.locator(`#${b64('prop.nonpriority_claims[0].city')}`).fill(np.city);
+  await page.locator(`select#${b64('prop.nonpriority_claims[0].state')}`).selectOption(np.state);
+  await page.locator(`#${b64('prop.nonpriority_claims[0].zip')}`).fill(np.zip);
+  // 'who' dropdown — always visible (code-generated choices)
+  const npWhoSelect = page.locator(`select#${b64('prop.nonpriority_claims[0].who')}`);
+  if (await npWhoSelect.count() > 0) await npWhoSelect.selectOption('Debtor 1 only');
 
-    await waitForDaPageLoad(page);
-    const np = scenario.creditors.nonpriority;
-    await page.locator(`#${b64('prop.nonpriority_claims[0].name')}`).fill(np.name);
-    await page.locator(`#${b64('prop.nonpriority_claims[0].street')}`).fill(np.street);
-    await page.locator(`#${b64('prop.nonpriority_claims[0].city')}`).fill(np.city);
-    await page.locator(`select#${b64('prop.nonpriority_claims[0].state')}`).selectOption(np.state);
-    await page.locator(`#${b64('prop.nonpriority_claims[0].zip')}`).fill(np.zip);
-    // 'who' dropdown — always visible (code-generated choices)
-    const npWhoSelect = page.locator(`select#${b64('prop.nonpriority_claims[0].who')}`);
-    if (await npWhoSelect.count() > 0) await npWhoSelect.selectOption('Debtor 1 only');
+  // Claim type dropdown (required)
+  const npTypeSelect = page.locator(`select#${b64('prop.nonpriority_claims[0].type')}`);
+  if (await npTypeSelect.count() > 0) await npTypeSelect.selectOption(np.type);
 
-    // Claim type dropdown (required)
-    const npTypeSelect = page.locator(`select#${b64('prop.nonpriority_claims[0].type')}`);
-    if (await npTypeSelect.count() > 0) await npTypeSelect.selectOption(np.type);
+  await page.locator(`#${b64('prop.nonpriority_claims[0].total_claim')}`).fill(np.totalClaim);
+  await fillYesNoRadio(page, 'prop.nonpriority_claims[0].save_to_library', false);
+  await fillYesNoRadio(page, 'prop.nonpriority_claims[0].has_codebtor', false);
+  await fillYesNoRadio(page, 'prop.nonpriority_claims[0].has_notify', false);
 
-    await page.locator(`#${b64('prop.nonpriority_claims[0].total_claim')}`).fill(np.totalClaim);
-    await fillYesNoRadio(page, 'prop.nonpriority_claims[0].save_to_library', false);
-    await fillYesNoRadio(page, 'prop.nonpriority_claims[0].has_codebtor', false);
-
-    // "Do others need to be notified about debt?" radio
-    await fillYesNoRadio(page, 'prop.nonpriority_claims[0].has_notify', false);
-
-    await clickContinue(page);
-
-    await handleAnotherPage(page, 'prop.nonpriority_claims.there_is_another');
-  } else {
-    await clickYesNoButton(page, 'prop.nonpriority_claims.there_are_any', false);
-  }
+  await clickContinue(page);
+  await handleAnotherPage(page, 'prop.nonpriority_claims.there_is_another');
 }
 
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Two clinic decisions:

**1. Exemptions restricted to the filing state** (supersedes #37 'show both'). Filing in Nebraska shows Nebraska exemptions only; South Dakota shows SD only. New `get_exemption_choices_or_combined(state, type)` (filters to a supported state; falls back to the NE+SD union when unknown) + an `exemption_filing_state` code block derived from the district; all 95 dropdown call-sites route through it. The #37 runtime test is updated to assert NE-only for a NE filing.

**2. Removed the nonpriority unsecured-claims gate** — `prop.nonpriority_claims.there_are_any` is forced True so the interview goes straight to the list (virtually every filer has one). Test helper fills the first claim (default for scenarios without one).

Note: saving creditors to the shared library was **already** available on every creditor form (106D/106EF) — that matching decision needs no code change.

Verified: exemption-runtime (NE-only), exemption-consistency, roxanne-feedback-fixes, and homeowner/simple/joint/complex scenarios all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)