### PR TITLE
Inline exemption flow: drop confusing '<100% FMV' question, always show amount (all 48 property types)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -15,6 +15,20 @@ code: |
   else:
     exemption_filing_state = ''
 ---
+code: |
+  # "Are you claiming less than 100% of fair market value?" is no longer asked
+  # on the property pages (clinic feedback — confusing/premature). Derive it from
+  # the entered exemption amount vs. the owned value: amount < owned value means a
+  # partial (specific-dollar) claim; otherwise it's a 100%/fair-market claim.
+  # Safe by construction — never errors; defaults to False (= 100% / fair market).
+  try:
+    prop.interests[i].claiming_sub_100 = (
+      prop.interests[i].exemption_value is not None
+      and float(prop.interests[i].exemption_value) < float(prop.interests[i].current_owned_value)
+    )
+  except Exception:
+    prop.interests[i].claiming_sub_100 = False
+---
 id: schedule_ab_property_intro
 event: property_intro
 section: schedule_ab
@@ -179,29 +193,29 @@ fields:
     required: False
   - Claiming Exemption?: prop.interests[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.interests[i].claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.interests[i].is_claiming_exemption
   - note: First Exemption
     show if: prop.interests[i].is_claiming_exemption
-  - Value of exemption being claimed: prop.interests[i].exemption_value
-    datatype: currency
-    show if: prop.interests[i].claiming_sub_100
   - Specific laws that allow exemption: prop.interests[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'real_property')
     show if: prop.interests[i].is_claiming_exemption
-  - note: Second Exemption
-    show if: prop.interests[i].is_claiming_exemption
-  - Value of exemption being claimed: prop.interests[i].exemption_value_2
+  - Amount you're claiming as exempt: prop.interests[i].exemption_value
     datatype: currency
-    show if: prop.interests[i].claiming_sub_100
-    required: False
-  - Specific laws that allow exemption: prop.interests[i].exemption_laws_2
+    help: |
+      Enter the value you're claiming as exempt — the full owned value to claim
+      100% of fair market value, or a smaller dollar amount for a partial claim.
+    show if: prop.interests[i].is_claiming_exemption
+  - note: Second exemption (optional — only if a second law also applies)
+    show if: prop.interests[i].is_claiming_exemption
+  - Specific laws that allow exemption (second): prop.interests[i].exemption_laws_2
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state, 'real_property')
+    show if: prop.interests[i].is_claiming_exemption
+    required: False
+  - Amount you're claiming as exempt (second): prop.interests[i].exemption_value_2
+    datatype: currency
     show if: prop.interests[i].is_claiming_exemption
     required: False
 list collect: True

--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -18,16 +18,10 @@ code: |
 code: |
   # "Are you claiming less than 100% of fair market value?" is no longer asked
   # on the property pages (clinic feedback — confusing/premature). Derive it from
-  # the entered exemption amount vs. the owned value: amount < owned value means a
-  # partial (specific-dollar) claim; otherwise it's a 100%/fair-market claim.
-  # Safe by construction — never errors; defaults to False (= 100% / fair market).
-  try:
-    prop.interests[i].claiming_sub_100 = (
-      prop.interests[i].exemption_value is not None
-      and float(prop.interests[i].exemption_value) < float(prop.interests[i].current_owned_value)
-    )
-  except Exception:
-    prop.interests[i].claiming_sub_100 = False
+  # the entered exemption amount vs. the owned value via claiming_less_than_full().
+  prop.interests[i].claiming_sub_100 = claiming_less_than_full(
+    prop.interests[i].exemption_value if defined('prop.interests[i].exemption_value') else None,
+    prop.interests[i].current_owned_value if defined('prop.interests[i].current_owned_value') else None)
 ---
 id: schedule_ab_property_intro
 event: property_intro
@@ -335,15 +329,12 @@ fields:
     input type: area
   - Claiming Exemption?: prop.ab_vehicles[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.ab_vehicles[i].claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.ab_vehicles[i].is_claiming_exemption
   - note: First Exemption
     show if: prop.ab_vehicles[i].is_claiming_exemption
   - Value of exemption being claimed: prop.ab_vehicles[i].exemption_value
     datatype: currency
     required: False
-    show if: prop.ab_vehicles[i].claiming_sub_100
+    show if: prop.ab_vehicles[i].is_claiming_exemption
   - Specific laws that allow exemption: prop.ab_vehicles[i].exemption_laws
     choices:
       code: |
@@ -353,7 +344,7 @@ fields:
     show if: prop.ab_vehicles[i].is_claiming_exemption
   - Value of exemption being claimed: prop.ab_vehicles[i].exemption_value_2
     datatype: currency
-    show if: prop.ab_vehicles[i].claiming_sub_100
+    show if: prop.ab_vehicles[i].is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.ab_vehicles[i].exemption_laws_2
     choices:
@@ -461,14 +452,11 @@ fields:
     datatype: yesnoradio
   - Claiming Exemption?: prop.ab_other_vehicles[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.ab_other_vehicles[i].claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - note: Exemption 1
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - Value of exemption being claimed: prop.ab_other_vehicles[i].exemption_value
     datatype: currency
-    show if: prop.ab_other_vehicles[i].claiming_sub_100
+    show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws
     choices:
       code: |
@@ -478,7 +466,7 @@ fields:
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - Value of exemption being claimed: prop.ab_other_vehicles[i].exemption_value_2
     datatype: currency
-    show if: prop.ab_other_vehicles[i].claiming_sub_100
+    show if: prop.ab_other_vehicles[i].is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws_2
     choices:
@@ -608,14 +596,11 @@ fields:
     show if: prop.has_household_goods
   - Claiming Exemption?: prop.household_goods_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.household_goods_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.household_goods_is_claiming_exemption
   - note: Exemption 1
     show if: prop.household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.household_goods_exemption_value
     datatype: currency
-    show if: prop.household_goods_claiming_sub_100
+    show if: prop.household_goods_is_claiming_exemption
   - Specific laws that allow exemption: prop.household_goods_exemption_laws
     choices:
       code: |
@@ -625,7 +610,7 @@ fields:
     show if: prop.household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.household_goods_exemption_value_2
     datatype: currency
-    show if: prop.household_goods_claiming_sub_100
+    show if: prop.household_goods_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.household_goods_exemption_laws_2
     choices:
@@ -646,14 +631,11 @@ fields:
     show if: prop.has_secured_household_goods
   - Claiming Exemption?: prop.secured_household_goods_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.secured_household_goods_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.secured_household_goods_is_claiming_exemption
   - note: Exemption 1
     show if: prop.secured_household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.secured_household_goods_exemption_value
     datatype: currency
-    show if: prop.secured_household_goods_claiming_sub_100
+    show if: prop.secured_household_goods_is_claiming_exemption
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws
     choices:
       code: |
@@ -663,7 +645,7 @@ fields:
     show if: prop.secured_household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.secured_household_goods_exemption_value_2
     datatype: currency
-    show if: prop.secured_household_goods_claiming_sub_100
+    show if: prop.secured_household_goods_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws_2
     choices:
@@ -684,14 +666,11 @@ fields:
     show if: prop.has_electronics
   - Claiming Exemption?: prop.electronics_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.electronics_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.electronics_is_claiming_exemption
   - note: First Exemption
     show if: prop.electronics_is_claiming_exemption
   - Value of exemption being claimed: prop.electronics_exemption_value
     datatype: currency
-    show if: prop.electronics_claiming_sub_100
+    show if: prop.electronics_is_claiming_exemption
   - Specific laws that allow exemption: prop.electronics_exemption_laws
     choices:
       code: |
@@ -701,7 +680,7 @@ fields:
     show if: prop.electronics_is_claiming_exemption
   - Value of exemption being claimed: prop.electronics_exemption_value_2
     datatype: currency
-    show if: prop.electronics_claiming_sub_100
+    show if: prop.electronics_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.electronics_exemption_laws_2
     choices:
@@ -722,14 +701,11 @@ fields:
     show if: prop.has_collectibles
   - Claiming Exemption?: prop.collectibles_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.collectibles_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.collectibles_is_claiming_exemption
   - note: First Exemption
     show if: prop.collectibles_is_claiming_exemption
   - Value of exemption being claimed: prop.collectibles_exemption_value
     datatype: currency
-    show if: prop.collectibles_claiming_sub_100
+    show if: prop.collectibles_is_claiming_exemption
   - Specific laws that allow exemption: prop.collectibles_exemption_laws
     choices:
       code: |
@@ -739,7 +715,7 @@ fields:
     show if: prop.collectibles_is_claiming_exemption
   - Value of exemption being claimed: prop.collectibles_exemption_value_2
     datatype: currency
-    show if: prop.collectibles_claiming_sub_100
+    show if: prop.collectibles_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.collectibles_exemption_laws_2
     choices:
@@ -760,14 +736,11 @@ fields:
     show if: prop.has_hobby_equipment
   - Claiming Exemption?: prop.hobby_equipment_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.hobby_equipment_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.hobby_equipment_is_claiming_exemption
   - note: First Exemption
     show if: prop.hobby_equipment_is_claiming_exemption
   - Value of exemption being claimed: prop.hobby_equipment_exemption_value
     datatype: currency
-    show if: prop.hobby_equipment_claiming_sub_100
+    show if: prop.hobby_equipment_is_claiming_exemption
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws
     choices:
       code: |
@@ -777,7 +750,7 @@ fields:
     show if: prop.hobby_equipment_is_claiming_exemption
   - Value of exemption being claimed: prop.hobby_equipment_exemption_value_2
     datatype: currency
-    show if: prop.hobby_equipment_claiming_sub_100
+    show if: prop.hobby_equipment_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws_2
     choices:
@@ -798,14 +771,11 @@ fields:
     show if: prop.has_firearms
   - Claiming Exemption?: prop.firearms_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.firearms_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.firearms_is_claiming_exemption
   - note: First Exemption
     show if: prop.firearms_is_claiming_exemption
   - Value of exemption being claimed: prop.firearms_exemption_value
     datatype: currency
-    show if: prop.firearms_claiming_sub_100
+    show if: prop.firearms_is_claiming_exemption
   - Specific laws that allow exemption: prop.firearms_exemption_laws
     choices:
       code: |
@@ -815,7 +785,7 @@ fields:
     show if: prop.firearms_is_claiming_exemption
   - Value of exemption being claimed: prop.firearms_exemption_value_2
     datatype: currency
-    show if: prop.firearms_claiming_sub_100
+    show if: prop.firearms_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.firearms_exemption_laws_2
     choices:
@@ -836,14 +806,11 @@ fields:
     show if: prop.has_clothes
   - Claiming Exemption?: prop.clothes_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.clothes_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.clothes_is_claiming_exemption
   - note: First Exemption
     show if: prop.clothes_is_claiming_exemption
   - Value of exemption being claimed: prop.clothes_exemption_value
     datatype: currency
-    show if: prop.clothes_claiming_sub_100
+    show if: prop.clothes_is_claiming_exemption
   - Specific laws that allow exemption: prop.clothes_exemption_laws
     choices:
       code: |
@@ -853,7 +820,7 @@ fields:
     show if: prop.clothes_is_claiming_exemption
   - Value of exemption being claimed: prop.clothes_exemption_value_2
     datatype: currency
-    show if: prop.clothes_claiming_sub_100
+    show if: prop.clothes_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.clothes_exemption_laws_2
     choices:
@@ -874,14 +841,11 @@ fields:
     show if: prop.has_jewelry
   - Claiming Exemption?: prop.jewelry_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.jewelry_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.jewelry_is_claiming_exemption
   - note: First Exemption
     show if: prop.jewelry_is_claiming_exemption
   - Value of exemption being claimed: prop.jewelry_exemption_value
     datatype: currency
-    show if: prop.jewelry_claiming_sub_100
+    show if: prop.jewelry_is_claiming_exemption
   - Specific laws that allow exemption: prop.jewelry_exemption_laws
     choices:
       code: |
@@ -891,7 +855,7 @@ fields:
     show if: prop.jewelry_is_claiming_exemption
   - Value of exemption being claimed: prop.jewelry_exemption_value_2
     datatype: currency
-    show if: prop.jewelry_claiming_sub_100
+    show if: prop.jewelry_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.jewelry_exemption_laws_2
     choices:
@@ -912,14 +876,11 @@ fields:
     show if: prop.has_animals
   - Claiming Exemption?: prop.animal_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.animal_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.animal_is_claiming_exemption
   - note: First Exemption
     show if: prop.animal_is_claiming_exemption
   - Value of exemption being claimed: prop.animal_exemption_value
     datatype: currency
-    show if: prop.animal_claiming_sub_100
+    show if: prop.animal_is_claiming_exemption
   - Specific laws that allow exemption: prop.animal_exemption_laws
     choices:
       code: |
@@ -929,7 +890,7 @@ fields:
     show if: prop.animal_is_claiming_exemption
   - Value of exemption being claimed: prop.animal_exemption_value_2
     datatype: currency
-    show if: prop.animal_claiming_sub_100
+    show if: prop.animal_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.animal_exemption_laws_2
     choices:
@@ -950,14 +911,11 @@ fields:
     show if: prop.has_other_household_items
   - Claiming Exemption?: prop.other_household_items_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.other_household_items_claiming_sub_100
-    datatype: yesnoradio
-    show if: prop.other_household_items_is_claiming_exemption
   - note: First Exemption
     show if: prop.other_household_items_is_claiming_exemption
   - Value of exemption being claimed: prop.other_household_items_exemption_value
     datatype: currency
-    show if: prop.other_household_items_claiming_sub_100
+    show if: prop.other_household_items_is_claiming_exemption
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws
     choices:
       code: |
@@ -967,7 +925,7 @@ fields:
     show if: prop.other_household_items_is_claiming_exemption
   - Value of exemption being claimed: prop.other_household_items_exemption_value_2
     datatype: currency
-    show if: prop.other_household_items_claiming_sub_100
+    show if: prop.other_household_items_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws_2
     choices:
@@ -1012,14 +970,11 @@ fields:
     show if: prop.financial_assets.has_cash
   - Claiming Exemption?: prop.financial_assets.cash_is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.cash_sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.cash_is_claiming_exemption
   - note: First Exemption
     show if: prop.financial_assets.cash_is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.cash_exemption_value
     datatype: currency
-    show if: prop.financial_assets.cash_sub_100
+    show if: prop.financial_assets.cash_is_claiming_exemption
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws
     choices:
       code: |
@@ -1029,7 +984,7 @@ fields:
     show if: prop.financial_assets.cash_is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.cash_exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.cash_sub_100
+    show if: prop.financial_assets.cash_is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws_2
     choices:
@@ -1103,14 +1058,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.deposits[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.deposits[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - note: First Exemption
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.deposits[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.deposits[i].sub_100
+    show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws
     choices:
       code: |
@@ -1120,7 +1072,7 @@ fields:
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.deposits[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.deposits[i].sub_100
+    show if: prop.financial_assets.deposits[i].is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws_2
     choices:
@@ -1187,14 +1139,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.bonds_and_stocks[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - note: First Exemption
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.bonds_and_stocks[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.bonds_and_stocks[i].sub_100
+    show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws
     choices:
       code: |
@@ -1204,7 +1153,7 @@ fields:
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.bonds_and_stocks[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.bonds_and_stocks[i].sub_100
+    show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws_2
     choices:
@@ -1275,14 +1224,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.non_traded_stock[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - note: First Exemption
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.non_traded_stock[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.non_traded_stock[i].sub_100
+    show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws
     choices:
       code: |
@@ -1292,7 +1238,7 @@ fields:
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.non_traded_stock[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.non_traded_stock[i].sub_100
+    show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
     required: false
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws_2
     choices:
@@ -1359,14 +1305,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.corporate_bonds[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - note: First Exemption
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.corporate_bonds[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.corporate_bonds[i].sub_100
+    show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws
     choices:
       code: |
@@ -1376,7 +1319,7 @@ fields:
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.corporate_bonds[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.corporate_bonds[i].sub_100
+    show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
     required: False
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws_2
     choices:
@@ -1454,14 +1397,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.retirement_accounts[i].has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.retirement_accounts[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.retirement_accounts[i].has_claim
   - note: First Exemption
     show if: prop.financial_assets.retirement_accounts[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.retirement_accounts[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.retirement_accounts[i].sub_100
+    show if: prop.financial_assets.retirement_accounts[i].has_claim
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws
     choices:
       code: |
@@ -1471,7 +1411,7 @@ fields:
     show if: prop.financial_assets.retirement_accounts[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.retirement_accounts[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.retirement_accounts[i].sub_100
+    show if: prop.financial_assets.retirement_accounts[i].has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws_2
     choices:
@@ -1552,14 +1492,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.prepayments[i].has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.prepayments[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.prepayments[i].has_claim
   - note: First Exemption
     show if: prop.financial_assets.prepayments[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.prepayments[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.prepayments[i].sub_100
+    show if: prop.financial_assets.prepayments[i].has_claim
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws
     choices:
       code: |
@@ -1569,7 +1506,7 @@ fields:
     show if: prop.financial_assets.prepayments[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.prepayments[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.prepayments[i].sub_100
+    show if: prop.financial_assets.prepayments[i].has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws_2
     choices:
@@ -1637,14 +1574,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.annuities[i].has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.annuities[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.annuities[i].has_claim
   - note: First Exemption
     show if: prop.financial_assets.annuities[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.annuities[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.annuities[i].sub_100
+    show if: prop.financial_assets.annuities[i].has_claim
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws
     choices:
       code: |
@@ -1654,7 +1588,7 @@ fields:
     show if: prop.financial_assets.annuities[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.annuities[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.annuities[i].sub_100
+    show if: prop.financial_assets.annuities[i].has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws_2
     choices:
@@ -1722,14 +1656,11 @@ fields:
     datatype: currency
   - Claiming Exemption?: prop.financial_assets.edu_accounts[i].has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.edu_accounts[i].sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.edu_accounts[i].has_claim
   - note: First Exemption
     show if: prop.financial_assets.edu_accounts[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.edu_accounts[i].exemption_value
     datatype: currency
-    show if: prop.financial_assets.edu_accounts[i].sub_100
+    show if: prop.financial_assets.edu_accounts[i].has_claim
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws
     choices:
       code: |
@@ -1739,7 +1670,7 @@ fields:
     show if: prop.financial_assets.edu_accounts[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.edu_accounts[i].exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.edu_accounts[i].sub_100
+    show if: prop.financial_assets.edu_accounts[i].has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws_2
     choices:
@@ -1785,14 +1716,11 @@ fields:
   - Claiming Exemption?: prop.financial_assets.future_property_interest_has_claim
     datatype: yesnoradio
     show if: prop.financial_assets.has_future_property_interest
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.future_property_interest_sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.future_property_interest_has_claim
   - note: First Exemption
     show if: prop.financial_assets.future_property_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.future_property_interest_exemption_value
     datatype: currency
-    show if: prop.financial_assets.future_property_interest_sub_100
+    show if: prop.financial_assets.future_property_interest_has_claim
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws
     choices:
       code: |
@@ -1802,7 +1730,7 @@ fields:
     show if: prop.financial_assets.future_property_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.future_property_interest_exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.future_property_interest_sub_100
+    show if: prop.financial_assets.future_property_interest_has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws_2
     choices:
@@ -1849,14 +1777,11 @@ fields:
   - Claiming Exemption?: prop.financial_assets.ip_interest_has_claim
     datatype: yesnoradio
     show if: prop.financial_assets.has_ip_interest
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.ip_interest_sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.ip_interest_has_claim
   - note: First Exemption
     show if: prop.financial_assets.ip_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.ip_interest_exemption_value
     datatype: currency
-    show if: prop.financial_assets.ip_interest_sub_100
+    show if: prop.financial_assets.ip_interest_has_claim
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws
     choices:
       code: |
@@ -1866,7 +1791,7 @@ fields:
     show if: prop.financial_assets.ip_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.ip_interest_exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.ip_interest_sub_100
+    show if: prop.financial_assets.ip_interest_has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws_2
     choices:
@@ -1912,14 +1837,11 @@ fields:
   - Claiming Exemption?: prop.financial_assets.intangible_interest_has_claim
     datatype: yesnoradio
     show if: prop.financial_assets.has_intangible_interest
-  - Are you claiming less than 100% of fair market value?: prop.financial_assets.intangible_interest_sub_100
-    datatype: yesnoradio
-    show if: prop.financial_assets.intangible_interest_has_claim
   - note: First Exemption
     show if: prop.financial_assets.intangible_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.intangible_interest_exemption_value
     datatype: currency
-    show if: prop.financial_assets.intangible_interest_sub_100
+    show if: prop.financial_assets.intangible_interest_has_claim
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws
     choices:
       code: |
@@ -1929,7 +1851,7 @@ fields:
     show if: prop.financial_assets.intangible_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.intangible_interest_exemption_value_2
     datatype: currency
-    show if: prop.financial_assets.intangible_interest_sub_100
+    show if: prop.financial_assets.intangible_interest_has_claim
     required: False
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws_2
     choices:
@@ -2074,9 +1996,6 @@ fields:
     required: False
   - Claiming Exemption?: prop.owed_property.tax_refund_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.tax_refund_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.tax_refund_has_claim
   - note: First Exemption
     show if: prop.owed_property.tax_refund_has_claim
   - Value of exemption being claimed: prop.owed_property.tax_refund_exemption_value
@@ -2132,14 +2051,11 @@ fields:
     required: False
   - Claiming Exemption?: prop.owed_property.family_support_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.family_support_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.family_support_has_claim
   - note: First Exemption
     show if: prop.owed_property.family_support_has_claim
   - Value of exemption being claimed: prop.owed_property.family_support_exemption_value
     datatype: currency
-    show if: prop.owed_property.family_support_sub_100
+    show if: prop.owed_property.family_support_has_claim
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws
     choices:
       code: |
@@ -2149,7 +2065,7 @@ fields:
     show if: prop.owed_property.family_support_has_claim
   - Value of exemption being claimed: prop.owed_property.family_support_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.family_support_sub_100
+    show if: prop.owed_property.family_support_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws_2
     choices:
@@ -2175,14 +2091,11 @@ fields:
     show if: prop.owed_property.has_other_amounts
   - Claiming Exemption?: prop.owed_property.other_amounts_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.other_amounts_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.other_amounts_has_claim
   - note: First Exemption
     show if: prop.owed_property.other_amounts_has_claim
   - Value of exemption being claimed: prop.owed_property.other_amounts_exemption_value
     datatype: currency
-    show if: prop.owed_property.other_amounts_sub_100
+    show if: prop.owed_property.other_amounts_has_claim
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws
     choices:
       code: |
@@ -2192,7 +2105,7 @@ fields:
     show if: prop.owed_property.other_amounts_has_claim
   - Value of exemption being claimed: prop.owed_property.other_amounts_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.other_amounts_sub_100
+    show if: prop.owed_property.other_amounts_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws_2
     choices:
@@ -2222,14 +2135,11 @@ fields:
     show if: prop.owed_property.has_insurance_interest
   - Claiming Exemption?: prop.owed_property.first_insurance_interest_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.first_insurance_interest_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.first_insurance_interest_has_claim
   - note: First Exemption
     show if: prop.owed_property.first_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.first_insurance_interest_exemption_value
     datatype: currency
-    show if: prop.owed_property.first_insurance_interest_sub_100
+    show if: prop.owed_property.first_insurance_interest_has_claim
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws
     choices:
       code: |
@@ -2239,7 +2149,7 @@ fields:
     show if: prop.owed_property.first_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.first_insurance_interest_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.first_insurance_interest_sub_100
+    show if: prop.owed_property.first_insurance_interest_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws_2
     choices:
@@ -2266,14 +2176,11 @@ fields:
   - Claiming Exemption?: prop.owed_property.second_insurance_interest_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_second_insurance_interest
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.second_insurance_interest_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.second_insurance_interest_has_claim
   - note: First Exemption
     show if: prop.owed_property.second_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.second_insurance_interest_exemption_value
     datatype: currency
-    show if: prop.owed_property.second_insurance_interest_sub_100
+    show if: prop.owed_property.second_insurance_interest_has_claim
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws
     choices:
       code: |
@@ -2283,7 +2190,7 @@ fields:
     show if: prop.owed_property.second_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.second_insurance_interest_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.second_insurance_interest_sub_100
+    show if: prop.owed_property.second_insurance_interest_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws_2
     choices:
@@ -2310,14 +2217,11 @@ fields:
   - Claiming Exemption?: prop.owed_property.third_insurance_interest_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_third_insurance_interest
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.third_insurance_interest_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.third_insurance_interest_has_claim
   - note: First Exemption
     show if: prop.owed_property.third_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.third_insurance_interest_exemption_value
     datatype: currency
-    show if: prop.owed_property.third_insurance_interest_sub_100
+    show if: prop.owed_property.third_insurance_interest_has_claim
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws
     choices:
       code: |
@@ -2327,7 +2231,7 @@ fields:
     show if: prop.owed_property.third_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.third_insurance_interest_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.third_insurance_interest_sub_100
+    show if: prop.owed_property.third_insurance_interest_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws_2
     choices:
@@ -2354,14 +2258,11 @@ fields:
   - Claiming Exemption?: prop.owed_property.trust_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_trust
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.trust_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.trust_has_claim
   - note: First Exemption
     show if: prop.owed_property.trust_has_claim
   - Value of exemption being claimed: prop.owed_property.trust_exemption_value
     datatype: currency
-    show if: prop.owed_property.trust_sub_100
+    show if: prop.owed_property.trust_has_claim
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws
     choices:
       code: |
@@ -2371,7 +2272,7 @@ fields:
     show if: prop.owed_property.trust_has_claim
   - Value of exemption being claimed: prop.owed_property.trust_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.trust_sub_100
+    show if: prop.owed_property.trust_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws_2
     choices:
@@ -2398,14 +2299,11 @@ fields:
   - Claiming Exemption?: prop.owed_property.third_party_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_third_party
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.third_party_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.third_party_has_claim
   - note: First Exemption
     show if: prop.owed_property.third_party_has_claim
   - Value of exemption being claimed: prop.owed_property.third_party_exemption_value
     datatype: currency
-    show if: prop.owed_property.third_party_sub_100
+    show if: prop.owed_property.third_party_has_claim
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws
     choices:
       code: |
@@ -2415,7 +2313,7 @@ fields:
     show if: prop.owed_property.third_party_has_claim
   - Value of exemption being claimed: prop.owed_property.third_party_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.third_party_sub_100
+    show if: prop.owed_property.third_party_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws_2
     choices:
@@ -2440,14 +2338,11 @@ fields:
   - Claiming Exemption?: prop.owed_property.contingent_claims_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_contingent_claims
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.contingent_claims_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.contingent_claims_has_claim
   - note: First Exemption
     show if: prop.owed_property.contingent_claims_has_claim
   - Value of exemption being claimed: prop.owed_property.contingent_claims_exemption_value
     datatype: currency
-    show if: prop.owed_property.contingent_claims_sub_100
+    show if: prop.owed_property.contingent_claims_has_claim
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws
     choices:
       code: |
@@ -2457,7 +2352,7 @@ fields:
     show if: prop.owed_property.contingent_claims_has_claim
   - Value of exemption being claimed: prop.owed_property.contingent_claims_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.contingent_claims_sub_100
+    show if: prop.owed_property.contingent_claims_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws_2
     choices:
@@ -2483,14 +2378,11 @@ fields:
   - Claiming Exemption?: prop.owed_property.other_assets_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_other_assets
-  - Are you claiming less than 100% of fair market value?: prop.owed_property.other_assets_sub_100
-    datatype: yesnoradio
-    show if: prop.owed_property.other_assets_has_claim
   - note: First Exemption
     show if: prop.owed_property.other_assets_has_claim
   - Value of exemption being claimed: prop.owed_property.other_assets_exemption_value
     datatype: currency
-    show if: prop.owed_property.other_assets_sub_100
+    show if: prop.owed_property.other_assets_has_claim
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws
     choices:
       code: |
@@ -2500,7 +2392,7 @@ fields:
     show if: prop.owed_property.other_assets_has_claim
   - Value of exemption being claimed: prop.owed_property.other_assets_exemption_value_2
     datatype: currency
-    show if: prop.owed_property.other_assets_sub_100
+    show if: prop.owed_property.other_assets_has_claim
     required: False
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws_2
     choices:
@@ -2615,14 +2507,11 @@ fields:
     show if: prop.business_property.has_ar
   - Claiming Exemption?: prop.business_property.ar_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.business_property.ar_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.ar_has_claim
   - note: First Exemption
     show if: prop.business_property.ar_has_claim
   - Value of exemption being claimed: prop.business_property.ar_exemption_value
     datatype: currency
-    show if: prop.business_property.ar_sub_100
+    show if: prop.business_property.ar_has_claim
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws
     choices:
       code: |
@@ -2632,7 +2521,7 @@ fields:
     show if: prop.business_property.ar_has_claim
   - Value of exemption being claimed: prop.business_property.ar_exemption_value_2
     datatype: currency
-    show if: prop.business_property.ar_sub_100
+    show if: prop.business_property.ar_has_claim
     required: False
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws_2
     choices:
@@ -2658,14 +2547,11 @@ fields:
     show if: prop.business_property.has_equipment
   - Claiming Exemption?: prop.business_property.equipment_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.business_property.equipment_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.equipment_has_claim
   - note: First Exemption
     show if: prop.business_property.equipment_has_claim
   - Value of exemption being claimed: prop.business_property.equipment_exemption_value
     datatype: currency
-    show if: prop.business_property.equipment_sub_100
+    show if: prop.business_property.equipment_has_claim
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws
     choices:
       code: |
@@ -2675,7 +2561,7 @@ fields:
     show if: prop.business_property.equipment_has_claim
   - Value of exemption being claimed: prop.business_property.equipment_exemption_value_2
     datatype: currency
-    show if: prop.business_property.equipment_sub_100
+    show if: prop.business_property.equipment_has_claim
     required: False
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws_2
     choices:
@@ -2700,14 +2586,11 @@ fields:
     show if: prop.business_property.has_machinery
   - Claiming Exemption?: prop.business_property.machinery_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.business_property.machinery_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.machinery_has_claim
   - note: First Exemption
     show if: prop.business_property.machinery_has_claim
   - Value of exemption being claimed: prop.business_property.machinery_exemption_value
     datatype: currency
-    show if: prop.business_property.machinery_sub_100
+    show if: prop.business_property.machinery_has_claim
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws
     choices:
       code: |
@@ -2717,7 +2600,7 @@ fields:
     show if: prop.business_property.machinery_has_claim
   - Value of exemption being claimed: prop.business_property.machinery_exemption_value_2
     datatype: currency
-    show if: prop.business_property.machinery_sub_100
+    show if: prop.business_property.machinery_has_claim
     required: False
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws_2
     choices:
@@ -2741,14 +2624,11 @@ fields:
     show if: prop.business_property.has_inventory
   - Claiming Exemption?: prop.business_property.inventory_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.business_property.inventory_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.inventory_has_claim
   - note: First Exemption
     show if: prop.business_property.inventory_has_claim
   - Value of exemption being claimed: prop.business_property.inventory_exemption_value
     datatype: currency
-    show if: prop.business_property.inventory_sub_100
+    show if: prop.business_property.inventory_has_claim
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws
     choices:
       code: |
@@ -2758,7 +2638,7 @@ fields:
     show if: prop.business_property.inventory_has_claim
   - Value of exemption being claimed: prop.business_property.inventory_exemption_value_2
     datatype: currency
-    show if: prop.business_property.inventory_sub_100
+    show if: prop.business_property.inventory_has_claim
     required: False
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws_2
     choices:
@@ -2830,14 +2710,11 @@ fields:
   - Claiming Exemption?: prop.business_property.partnership_has_claim
     datatype: yesnoradio
     show if: prop.business_property.has_partnerships
-  - Are you claiming less than 100% of fair market value?: prop.business_property.partnership_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.partnership_has_claim
   - note: First Exemption
     show if: prop.business_property.partnership_has_claim
   - Value of exemption being claimed: prop.business_property.partnership_exemption_value
     datatype: currency
-    show if: prop.business_property.partnership_sub_100
+    show if: prop.business_property.partnership_has_claim
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws
     choices:
       code: |
@@ -2847,7 +2724,7 @@ fields:
     show if: prop.business_property.partnership_has_claim
   - Value of exemption being claimed: prop.business_property.partnership_exemption_value_2
     datatype: currency
-    show if: prop.business_property.partnership_sub_100
+    show if: prop.business_property.partnership_has_claim
     required: False
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws_2
     choices:
@@ -2875,14 +2752,11 @@ fields:
     show if: prop.business_property.has_lists
   - Claiming Exemption?: prop.business_property.lists_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.business_property.lists_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.lists_has_claim
   - note: First Exemption
     show if: prop.business_property.lists_has_claim
   - Value of exemption being claimed: prop.business_property.lists_exemption_value
     datatype: currency
-    show if: prop.business_property.lists_sub_100
+    show if: prop.business_property.lists_has_claim
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws
     choices:
       code: |
@@ -2892,7 +2766,7 @@ fields:
     show if: prop.business_property.lists_has_claim
   - Value of exemption being claimed: prop.business_property.lists_exemption_value_2
     datatype: currency
-    show if: prop.business_property.lists_sub_100
+    show if: prop.business_property.lists_has_claim
     required: False
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws_2
     choices:
@@ -2951,14 +2825,11 @@ fields:
   - Claiming Exemption?: prop.business_property.otherProperty_has_claim
     datatype: yesnoradio
     show if: prop.business_property.has_other
-  - Are you claiming less than 100% of fair market value?: prop.business_property.otherProperty_sub_100
-    datatype: yesnoradio
-    show if: prop.business_property.otherProperty_has_claim
   - note: First Exemption
     show if: prop.business_property.otherProperty_has_claim
   - Value of exemption being claimed: prop.business_property.otherProperty_exemption_value
     datatype: currency
-    show if: prop.business_property.otherProperty_sub_100
+    show if: prop.business_property.otherProperty_has_claim
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws
     choices:
       code: |
@@ -2969,7 +2840,7 @@ fields:
   - Value of exemption being claimed: prop.business_property.otherProperty_exemption_value_2
     datatype: currency
     required: False
-    show if: prop.business_property.otherProperty_sub_100
+    show if: prop.business_property.otherProperty_has_claim
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws_2
     choices:
       code: |
@@ -3064,14 +2935,11 @@ fields:
     show if: prop.farming_property.has_animals
   - Claiming Exemption?: prop.farming_property.has_animal_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.farming_property.animal_sub_100
-    datatype: yesnoradio
-    show if: prop.farming_property.has_animal_claim
   - note: First Exemption
     show if: prop.farming_property.has_animal_claim
   - Value of exemption being claimed: prop.farming_property.animal_exemption_value
     datatype: currency
-    show if: prop.farming_property.animal_sub_100
+    show if: prop.farming_property.has_animal_claim
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws
     choices:
       code: |
@@ -3081,7 +2949,7 @@ fields:
     show if: prop.farming_property.has_animal_claim
   - Value of exemption being claimed: prop.farming_property.animal_exemption_value_2
     datatype: currency
-    show if: prop.farming_property.animal_sub_100
+    show if: prop.farming_property.has_animal_claim
     required: False
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws_2
     choices:
@@ -3105,14 +2973,11 @@ fields:
     #farm crops exemptions
   - Claiming Exemption?: prop.farming_property.has_crops_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.farming_property.crops_sub_100
-    datatype: yesnoradio
-    show if: prop.farming_property.has_crops_claim
   - note: First Exemption
     show if: prop.farming_property.has_crops_claim
   - Value of exemption being claimed: prop.farming_property.crops_exemption_value
     datatype: currency
-    show if: prop.farming_property.crops_sub_100
+    show if: prop.farming_property.has_crops_claim
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws
     choices:
       code: |
@@ -3122,7 +2987,7 @@ fields:
     show if: prop.farming_property.has_crops_claim
   - Value of exemption being claimed: prop.farming_property.crops_exemption_value_2
     datatype: currency
-    show if: prop.farming_property.crops_sub_100
+    show if: prop.farming_property.has_crops_claim
     required: False
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws_2
     choices:
@@ -3145,14 +3010,11 @@ fields:
     show if: prop.farming_property.has_equipment
   - Claiming Exemption?: prop.farming_property.has_equipment_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.farming_property.equipment_sub_100
-    datatype: yesnoradio
-    show if: prop.farming_property.has_equipment_claim
   - note: First Exemption
     show if: prop.farming_property.has_equipment_claim
   - Value of exemption being claimed: prop.farming_property.equipment_exemption_value
     datatype: currency
-    show if: prop.farming_property.equipment_sub_100
+    show if: prop.farming_property.has_equipment_claim
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws
     choices:
       code: |
@@ -3162,7 +3024,7 @@ fields:
     show if: prop.farming_property.has_equipment_claim
   - Value of exemption being claimed: prop.farming_property.equipment_exemption_value_2
     datatype: currency
-    show if: prop.farming_property.equipment_sub_100
+    show if: prop.farming_property.has_equipment_claim
     required: False
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws_2
     choices:
@@ -3185,14 +3047,11 @@ fields:
     show if: prop.farming_property.has_supplies
   - Claiming Exemption?: prop.farming_property.has_supplies_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.farming_property.supplies_sub_100
-    datatype: yesnoradio
-    show if: prop.farming_property.has_supplies_claim
   - note: First Exemption
     show if: prop.farming_property.has_supplies_claim
   - Value of exemption being claimed: prop.farming_property.supplies_exemption_value
     datatype: currency
-    show if: prop.farming_property.supplies_sub_100
+    show if: prop.farming_property.has_supplies_claim
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws
     choices:
       code: |
@@ -3202,7 +3061,7 @@ fields:
     show if: prop.farming_property.has_supplies_claim
   - Value of exemption being claimed: prop.farming_property.supplies_exemption_value_2
     datatype: currency
-    show if: prop.farming_property.supplies_sub_100
+    show if: prop.farming_property.has_supplies_claim
     required: False
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws_2
     choices:
@@ -3226,14 +3085,11 @@ fields:
     #farm fishing exemptions
   - Claiming Exemption?: prop.farming_property.has_fishing_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.farming_property.fishing_sub_100
-    datatype: yesnoradio
-    show if: prop.farming_property.has_fishing_claim
   - note: First Exemption
     show if: prop.farming_property.has_fishing_claim
   - Value of exemption being claimed: prop.farming_property.fishing_exemption_value
     datatype: currency
-    show if: prop.farming_property.fishing_sub_100
+    show if: prop.farming_property.has_fishing_claim
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws
     choices:
       code: |
@@ -3243,7 +3099,7 @@ fields:
     show if: prop.farming_property.has_fishing_claim
   - Value of exemption being claimed: prop.farming_property.fishing_exemption_value_2
     datatype: currency
-    show if: prop.farming_property.fishing_sub_100
+    show if: prop.farming_property.has_fishing_claim
     required: False
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws_2
     choices:
@@ -3307,14 +3163,11 @@ fields:
     show if: prop.has_third_other_prop
   - Claiming Exemption?: prop.other_prop_has_claim
     datatype: yesnoradio
-  - Are you claiming less than 100% of fair market value?: prop.other_prop_sub_100
-    datatype: yesnoradio
-    show if: prop.other_prop_has_claim
   - note: First Exemption
     show if: prop.other_prop_has_claim
   - Value of exemption being claimed: prop.other_prop_exemption_value
     datatype: currency
-    show if: prop.other_prop_sub_100
+    show if: prop.other_prop_has_claim
   - Specific laws that allow exemption: prop.other_prop_exemption_laws
     choices:
       code: |
@@ -3324,7 +3177,7 @@ fields:
     show if: prop.other_prop_has_claim
   - Value of exemption being claimed: prop.other_prop_exemption_value_2
     datatype: currency
-    show if: prop.other_prop_sub_100
+    show if: prop.other_prop_has_claim
     required: False
   - Specific laws that allow exemption: prop.other_prop_exemption_laws_2
     choices:
@@ -5610,3 +5463,241 @@ review:
 continue button field: prop.complete
 ---
 
+# ── Derived: 'claiming less than 100% of FMV' is no longer asked on the
+# property pages (clinic feedback). It's computed (amount < value) via
+# claiming_less_than_full() so the Schedule C PDF flags keep working.
+---
+code: |
+  prop.ab_vehicles[i].claiming_sub_100 = claiming_less_than_full(
+    prop.ab_vehicles[i].exemption_value if defined('prop.ab_vehicles[i].exemption_value') else None,
+    prop.ab_vehicles[i].current_value if defined('prop.ab_vehicles[i].current_value') else None)
+---
+code: |
+  prop.ab_other_vehicles[i].claiming_sub_100 = claiming_less_than_full(
+    prop.ab_other_vehicles[i].exemption_value if defined('prop.ab_other_vehicles[i].exemption_value') else None,
+    prop.ab_other_vehicles[i].current_value if defined('prop.ab_other_vehicles[i].current_value') else None)
+---
+code: |
+  prop.household_goods_claiming_sub_100 = claiming_less_than_full(
+    prop.household_goods_exemption_value if defined('prop.household_goods_exemption_value') else None,
+    prop.household_goods_value if defined('prop.household_goods_value') else None)
+---
+code: |
+  prop.secured_household_goods_claiming_sub_100 = claiming_less_than_full(
+    prop.secured_household_goods_exemption_value if defined('prop.secured_household_goods_exemption_value') else None,
+    prop.secured_household_goods_value if defined('prop.secured_household_goods_value') else None)
+---
+code: |
+  prop.electronics_claiming_sub_100 = claiming_less_than_full(
+    prop.electronics_exemption_value if defined('prop.electronics_exemption_value') else None,
+    prop.electronics_value if defined('prop.electronics_value') else None)
+---
+code: |
+  prop.collectibles_claiming_sub_100 = claiming_less_than_full(
+    prop.collectibles_exemption_value if defined('prop.collectibles_exemption_value') else None,
+    prop.collectibles_value if defined('prop.collectibles_value') else None)
+---
+code: |
+  prop.hobby_equipment_claiming_sub_100 = claiming_less_than_full(
+    prop.hobby_equipment_exemption_value if defined('prop.hobby_equipment_exemption_value') else None,
+    prop.hobby_equipment_value if defined('prop.hobby_equipment_value') else None)
+---
+code: |
+  prop.firearms_claiming_sub_100 = claiming_less_than_full(
+    prop.firearms_exemption_value if defined('prop.firearms_exemption_value') else None,
+    prop.firearms_value if defined('prop.firearms_value') else None)
+---
+code: |
+  prop.clothes_claiming_sub_100 = claiming_less_than_full(
+    prop.clothes_exemption_value if defined('prop.clothes_exemption_value') else None,
+    prop.clothes_value if defined('prop.clothes_value') else None)
+---
+code: |
+  prop.jewelry_claiming_sub_100 = claiming_less_than_full(
+    prop.jewelry_exemption_value if defined('prop.jewelry_exemption_value') else None,
+    prop.jewelry_value if defined('prop.jewelry_value') else None)
+---
+code: |
+  prop.animal_claiming_sub_100 = claiming_less_than_full(
+    prop.animal_exemption_value if defined('prop.animal_exemption_value') else None,
+    prop.animal_value if defined('prop.animal_value') else None)
+---
+code: |
+  prop.other_household_items_claiming_sub_100 = claiming_less_than_full(
+    prop.other_household_items_exemption_value if defined('prop.other_household_items_exemption_value') else None,
+    prop.other_household_items_value if defined('prop.other_household_items_value') else None)
+---
+code: |
+  prop.financial_assets.cash_sub_100 = claiming_less_than_full(
+    prop.financial_assets.cash_exemption_value if defined('prop.financial_assets.cash_exemption_value') else None,
+    prop.financial_assets.cash_value if defined('prop.financial_assets.cash_value') else None)
+---
+code: |
+  prop.financial_assets.deposits[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.deposits[i].exemption_value if defined('prop.financial_assets.deposits[i].exemption_value') else None,
+    prop.financial_assets.deposits[i].amount if defined('prop.financial_assets.deposits[i].amount') else None)
+---
+code: |
+  prop.financial_assets.bonds_and_stocks[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.bonds_and_stocks[i].exemption_value if defined('prop.financial_assets.bonds_and_stocks[i].exemption_value') else None,
+    prop.financial_assets.bonds_and_stocks[i].amount if defined('prop.financial_assets.bonds_and_stocks[i].amount') else None)
+---
+code: |
+  prop.financial_assets.non_traded_stock[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.non_traded_stock[i].exemption_value if defined('prop.financial_assets.non_traded_stock[i].exemption_value') else None,
+    prop.financial_assets.non_traded_stock[i].value if defined('prop.financial_assets.non_traded_stock[i].value') else None)
+---
+code: |
+  prop.financial_assets.corporate_bonds[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.corporate_bonds[i].exemption_value if defined('prop.financial_assets.corporate_bonds[i].exemption_value') else None,
+    prop.financial_assets.corporate_bonds[i].amount if defined('prop.financial_assets.corporate_bonds[i].amount') else None)
+---
+code: |
+  prop.financial_assets.retirement_accounts[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.retirement_accounts[i].exemption_value if defined('prop.financial_assets.retirement_accounts[i].exemption_value') else None,
+    prop.financial_assets.retirement_accounts[i].amount if defined('prop.financial_assets.retirement_accounts[i].amount') else None)
+---
+code: |
+  prop.financial_assets.prepayments[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.prepayments[i].exemption_value if defined('prop.financial_assets.prepayments[i].exemption_value') else None,
+    prop.financial_assets.prepayments[i].amount if defined('prop.financial_assets.prepayments[i].amount') else None)
+---
+code: |
+  prop.financial_assets.annuities[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.annuities[i].exemption_value if defined('prop.financial_assets.annuities[i].exemption_value') else None,
+    prop.financial_assets.annuities[i].amount if defined('prop.financial_assets.annuities[i].amount') else None)
+---
+code: |
+  prop.financial_assets.edu_accounts[i].sub_100 = claiming_less_than_full(
+    prop.financial_assets.edu_accounts[i].exemption_value if defined('prop.financial_assets.edu_accounts[i].exemption_value') else None,
+    prop.financial_assets.edu_accounts[i].amount if defined('prop.financial_assets.edu_accounts[i].amount') else None)
+---
+code: |
+  prop.financial_assets.future_property_interest_sub_100 = claiming_less_than_full(
+    prop.financial_assets.future_property_interest_exemption_value if defined('prop.financial_assets.future_property_interest_exemption_value') else None,
+    prop.financial_assets.future_property_interest_value if defined('prop.financial_assets.future_property_interest_value') else None)
+---
+code: |
+  prop.financial_assets.ip_interest_sub_100 = claiming_less_than_full(
+    prop.financial_assets.ip_interest_exemption_value if defined('prop.financial_assets.ip_interest_exemption_value') else None,
+    prop.financial_assets.ip_interest_value if defined('prop.financial_assets.ip_interest_value') else None)
+---
+code: |
+  prop.financial_assets.intangible_interest_sub_100 = claiming_less_than_full(
+    prop.financial_assets.intangible_interest_exemption_value if defined('prop.financial_assets.intangible_interest_exemption_value') else None,
+    prop.financial_assets.intangible_interest_value if defined('prop.financial_assets.intangible_interest_value') else None)
+---
+code: |
+  prop.owed_property.tax_refund_sub_100 = claiming_less_than_full(
+    prop.owed_property.tax_refund_exemption_value if defined('prop.owed_property.tax_refund_exemption_value') else None,
+    prop.owed_property.tax_refund_local if defined('prop.owed_property.tax_refund_local') else None)
+---
+code: |
+  prop.owed_property.family_support_sub_100 = claiming_less_than_full(
+    prop.owed_property.family_support_exemption_value if defined('prop.owed_property.family_support_exemption_value') else None,
+    prop.owed_property.family_support_settlement if defined('prop.owed_property.family_support_settlement') else None)
+---
+code: |
+  prop.owed_property.other_amounts_sub_100 = claiming_less_than_full(
+    prop.owed_property.other_amounts_exemption_value if defined('prop.owed_property.other_amounts_exemption_value') else None,
+    None)
+---
+code: |
+  prop.owed_property.first_insurance_interest_sub_100 = claiming_less_than_full(
+    prop.owed_property.first_insurance_interest_exemption_value if defined('prop.owed_property.first_insurance_interest_exemption_value') else None,
+    prop.owed_property.first_insurance_interest_amount if defined('prop.owed_property.first_insurance_interest_amount') else None)
+---
+code: |
+  prop.owed_property.second_insurance_interest_sub_100 = claiming_less_than_full(
+    prop.owed_property.second_insurance_interest_exemption_value if defined('prop.owed_property.second_insurance_interest_exemption_value') else None,
+    prop.owed_property.second_insurance_interest_amount if defined('prop.owed_property.second_insurance_interest_amount') else None)
+---
+code: |
+  prop.owed_property.third_insurance_interest_sub_100 = claiming_less_than_full(
+    prop.owed_property.third_insurance_interest_exemption_value if defined('prop.owed_property.third_insurance_interest_exemption_value') else None,
+    prop.owed_property.third_insurance_interest_amount if defined('prop.owed_property.third_insurance_interest_amount') else None)
+---
+code: |
+  prop.owed_property.trust_sub_100 = claiming_less_than_full(
+    prop.owed_property.trust_exemption_value if defined('prop.owed_property.trust_exemption_value') else None,
+    prop.owed_property.trust_amount if defined('prop.owed_property.trust_amount') else None)
+---
+code: |
+  prop.owed_property.third_party_sub_100 = claiming_less_than_full(
+    prop.owed_property.third_party_exemption_value if defined('prop.owed_property.third_party_exemption_value') else None,
+    prop.owed_property.third_party_amount if defined('prop.owed_property.third_party_amount') else None)
+---
+code: |
+  prop.owed_property.contingent_claims_sub_100 = claiming_less_than_full(
+    prop.owed_property.contingent_claims_exemption_value if defined('prop.owed_property.contingent_claims_exemption_value') else None,
+    prop.owed_property.contingent_claims_amount if defined('prop.owed_property.contingent_claims_amount') else None)
+---
+code: |
+  prop.owed_property.other_assets_sub_100 = claiming_less_than_full(
+    prop.owed_property.other_assets_exemption_value if defined('prop.owed_property.other_assets_exemption_value') else None,
+    prop.owed_property.other_assets_amount if defined('prop.owed_property.other_assets_amount') else None)
+---
+code: |
+  prop.business_property.ar_sub_100 = claiming_less_than_full(
+    prop.business_property.ar_exemption_value if defined('prop.business_property.ar_exemption_value') else None,
+    prop.business_property.ar_amount if defined('prop.business_property.ar_amount') else None)
+---
+code: |
+  prop.business_property.equipment_sub_100 = claiming_less_than_full(
+    prop.business_property.equipment_exemption_value if defined('prop.business_property.equipment_exemption_value') else None,
+    prop.business_property.equipment_amount if defined('prop.business_property.equipment_amount') else None)
+---
+code: |
+  prop.business_property.machinery_sub_100 = claiming_less_than_full(
+    prop.business_property.machinery_exemption_value if defined('prop.business_property.machinery_exemption_value') else None,
+    prop.business_property.machinery_amount if defined('prop.business_property.machinery_amount') else None)
+---
+code: |
+  prop.business_property.inventory_sub_100 = claiming_less_than_full(
+    prop.business_property.inventory_exemption_value if defined('prop.business_property.inventory_exemption_value') else None,
+    prop.business_property.inventory_amount if defined('prop.business_property.inventory_amount') else None)
+---
+code: |
+  prop.business_property.partnership_sub_100 = claiming_less_than_full(
+    prop.business_property.partnership_exemption_value if defined('prop.business_property.partnership_exemption_value') else None,
+    prop.business_property.partnershipValue5 if defined('prop.business_property.partnershipValue5') else None)
+---
+code: |
+  prop.business_property.lists_sub_100 = claiming_less_than_full(
+    prop.business_property.lists_exemption_value if defined('prop.business_property.lists_exemption_value') else None,
+    prop.business_property.lists_amount if defined('prop.business_property.lists_amount') else None)
+---
+code: |
+  prop.business_property.otherProperty_sub_100 = claiming_less_than_full(
+    prop.business_property.otherProperty_exemption_value if defined('prop.business_property.otherProperty_exemption_value') else None,
+    prop.business_property.otherPropertyAmount6 if defined('prop.business_property.otherPropertyAmount6') else None)
+---
+code: |
+  prop.farming_property.animal_sub_100 = claiming_less_than_full(
+    prop.farming_property.animal_exemption_value if defined('prop.farming_property.animal_exemption_value') else None,
+    prop.farming_property.animal_amount if defined('prop.farming_property.animal_amount') else None)
+---
+code: |
+  prop.farming_property.crops_sub_100 = claiming_less_than_full(
+    prop.farming_property.crops_exemption_value if defined('prop.farming_property.crops_exemption_value') else None,
+    prop.farming_property.crop_amount if defined('prop.farming_property.crop_amount') else None)
+---
+code: |
+  prop.farming_property.equipment_sub_100 = claiming_less_than_full(
+    prop.farming_property.equipment_exemption_value if defined('prop.farming_property.equipment_exemption_value') else None,
+    prop.farming_property.equipment_amount if defined('prop.farming_property.equipment_amount') else None)
+---
+code: |
+  prop.farming_property.supplies_sub_100 = claiming_less_than_full(
+    prop.farming_property.supplies_exemption_value if defined('prop.farming_property.supplies_exemption_value') else None,
+    prop.farming_property.supplies_amount if defined('prop.farming_property.supplies_amount') else None)
+---
+code: |
+  prop.farming_property.fishing_sub_100 = claiming_less_than_full(
+    prop.farming_property.fishing_exemption_value if defined('prop.farming_property.fishing_exemption_value') else None,
+    prop.farming_property.commercial_amount if defined('prop.farming_property.commercial_amount') else None)
+---
+code: |
+  prop.other_prop_sub_100 = claiming_less_than_full(
+    prop.other_prop_exemption_value if defined('prop.other_prop_exemption_value') else None,
+    prop.other_prop_value3 if defined('prop.other_prop_value3') else None)

--- a/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
@@ -56,7 +56,11 @@ code: |
       _item = prop.exempt_property.properties.appendObject()
       _item.description = _entry['description']
       _item.value = _entry['value']
-      _item.not_full_exemption = True
+      # "Less than 100% of FMV" is now derived (amount < value) rather than asked.
+      try:
+        _item.not_full_exemption = float(_entry['exemption']) < float(_entry['value'])
+      except Exception:
+        _item.not_full_exemption = False
       _item.exemption = _entry['exemption']
       _item.laws = _entry['laws']
       _item.line = _entry['line']

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -215,6 +215,26 @@ def get_exemption_choices_or_combined(state, property_type='all'):
                 return get_exemption_choices(s, property_type)
     return get_exemption_choices_combined(property_type)
 
+
+def claiming_less_than_full(amount, value):
+    """
+    Derive the Schedule C "claiming less than 100% of fair market value" flag.
+
+    The explicit question was removed from the property pages (clinic feedback);
+    instead we infer it: a claimed `amount` strictly less than the item's `value`
+    is a partial (specific-dollar) claim; an amount equal to (or above) the value
+    is a 100%/fair-market claim. Safe by construction — any bad/None input falls
+    back to False (= 100% / fair market, the debtor-favorable default).
+    """
+    try:
+        if amount is None or value is None:
+            return False
+        amt = float(str(amount).replace('$', '').replace(',', ''))
+        val = float(str(value).replace('$', '').replace(',', ''))
+        return amt < val
+    except (TypeError, ValueError):
+        return False
+
 def get_exemption_limits(user_state):
     """
     Returns a dict of exemption category -> dollar limit for the given state.

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -192,22 +192,18 @@ async function fillRealProperty(page: Page, rp: RealPropertyData, index: number)
   await fillYesNoRadio(page, `prop.interests[${index}].is_community_property`, false);
   await page.locator(`#${b64(`prop.interests[${index}].other_info`)}`).fill(rp.otherInfo);
   if (rp.claimExemption) {
-    // Claim a full (100%) wildcard exemption inline so we can verify Schedule C
-    // auto-populates without re-asking for the property. Use JS-based radio
-    // setting (selectYesNoRadio) — claiming_sub_100/exemption_laws are revealed
-    // by show-if, so a plain label click can race the reveal.
-    await selectYesNoRadio(page, `prop.interests[${index}].is_claiming_exemption`, true);
-    await page.waitForTimeout(800);
-    await selectYesNoRadio(page, `prop.interests[${index}].claiming_sub_100`, false);
-    await page.waitForTimeout(500);
-    const lawId = b64(`prop.interests[${index}].exemption_laws`);
-    const lawSel = page.locator(`select#${lawId}`);
+    // Claim an exemption inline: Yes -> pick a law -> enter the amount. The
+    // "<100% of FMV?" question was removed (clinic feedback); the law and amount
+    // are both revealed by is_claiming_exemption, so wait for each before acting.
+    await page.locator(`label[for="${b64(`prop.interests[${index}].is_claiming_exemption`)}_0"]`).click();
+    const lawSel = page.locator(`select#${b64(`prop.interests[${index}].exemption_laws`)}`);
+    await lawSel.waitFor({ state: 'visible', timeout: 15000 });
     const lawValue = 'Wildcard (Neb. Rev. Stat. § 25-1552)';
-    if (await lawSel.count() > 0) {
-      await lawSel.selectOption(lawValue).catch(() => lawSel.selectOption({ label: lawValue }).catch(() => {}));
-    } else {
-      await page.locator(`#${lawId}`).fill(lawValue).catch(() => {});
-    }
+    await lawSel.selectOption({ label: lawValue }).catch(() => lawSel.selectOption(lawValue).catch(() => {}));
+    const amt = page.locator(`#${b64(`prop.interests[${index}].exemption_value`)}`);
+    await amt.waitFor({ state: 'visible', timeout: 15000 });
+    // Full owned value -> 100% / fair-market claim (derived in 106AB).
+    await amt.fill(rp.value || '5000');
   } else {
     await fillYesNoRadio(page, `prop.interests[${index}].is_claiming_exemption`, false);
   }

--- a/tests/test_exemption_totals.py
+++ b/tests/test_exemption_totals.py
@@ -14,7 +14,8 @@ Run inside the docassemble container (it needs docassemble.base.util):
       docker exec docassemble /usr/share/docassemble/local3.12/bin/python /tmp/test_exemption_totals.py"
 """
 import types
-from docassemble.BankruptcyClinic.objects import compute_exemption_totals, NEBRASKA_EXEMPTIONS
+from docassemble.BankruptcyClinic.objects import (
+    compute_exemption_totals, NEBRASKA_EXEMPTIONS, claiming_less_than_full)
 
 WILD = NEBRASKA_EXEMPTIONS['wildcard']
 
@@ -55,9 +56,22 @@ def test_citation_has_no_bogus_subsection():
     assert WILD == 'Wildcard (Neb. Rev. Stat. § 25-1552)'
 
 
+def test_claiming_less_than_full_derivation():
+    """The '<100% of FMV' flag is derived: amount < value => partial (True),
+    amount == or > value => 100%/fair-market (False); bad input => False."""
+    assert claiming_less_than_full(1500, 4000) is True      # partial
+    assert claiming_less_than_full(4000, 4000) is False     # exactly 100%
+    assert claiming_less_than_full(5000, 4000) is False     # over -> 100%
+    assert claiming_less_than_full(None, 4000) is False     # no amount
+    assert claiming_less_than_full(1500, None) is False     # no value
+    assert claiming_less_than_full('$1,500', '$4,000') is True   # currency strings
+    assert claiming_less_than_full('bogus', 4000) is False  # unparseable
+
+
 if __name__ == '__main__':
     test_full_claim_counts_owned_value()
     test_partial_claim_uses_explicit_value()
     test_claim_without_law_ignored()
     test_citation_has_no_bogus_subsection()
+    test_claiming_less_than_full_derivation()
     print('OK: all exemption-totals unit tests passed')


### PR DESCRIPTION
Addresses Roxanne's note: *"I can pick a law but not an amount … it's always asking if I am claiming less than 100% of fair market value — not sure this is needed … VERY confusing."*

**What changed (all 48 property types):**
- Removed the **"Are you claiming less than 100% of fair market value?"** question from every property page.
- The **exemption amount is always shown** when claiming (was hidden unless you said "<100%"), so you can always enter it.
- Reworded the second exemption as clearly optional.

**How the Schedule C PDF still gets the right flag:** the *less-than-100%* distinction is now **derived** — `claiming_less_than_full(amount, value)`: amount < value ⇒ partial (specific-dollar) claim; amount == value ⇒ 100% / fair-market. The existing PDF code (`isCustExempt`/`isFairMarket`/`custExemptVal`) is untouched; the 106C auto-populate derives `not_full_exemption` the same way. Safe by construction (`defined()` guards + fallback to False/fair-market), so a bad/missing value field can never crash document generation.

**Verification:**
- In-container unit tests incl. `claiming_less_than_full` (partial/exact/over/None/currency-string/unparseable).
- No-regression: homeowner, simple-single, joint-couple full petitions + PDFs; exemption-runtime (flat-type claim, NE-only); roxanne-feedback-fixes.
- ⚠️ The **list-collect inline-claim** path (real estate, vehicles, financial assets) can't be auto-driven (docassemble show-if doesn't reveal from Playwright clicks; real users are fine). **Recommend a staff spot-check of a claimed Schedule C PDF on the test site.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)