### PR TITLE
Fix silent-block Continue on Schedule J household; add per-question Back button

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106J-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106J-question-blocks.yml
@@ -17,6 +17,7 @@ fields:
   - Does debtor 2 live in a separate household: debtor[0].expenses.other_household
     datatype: yesnoradio
     show if: debtor[0].expenses.joint_case
+    required: False
   - Do you have dependents?: debtor[0].expenses.dependents.there_are_any
     datatype: yesnoradio
   - Do your expenses include expenses of people other than yourself and your dependents?: debtor[0].expenses.other_people_expenses

--- a/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
@@ -41,6 +41,7 @@ fields:
     show if:
       variable: monthly_income.filing_status
       is: Married and your spouse is NOT filing with you.
+    required: False
   - How many dependents?: monthly_income.dependents
     datatype: number
     default: ${ len(debtor[0].expenses.dependents) if defined('debtor[0].expenses.dependents.gathered') else 0 }

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -64,6 +64,7 @@ features:
   navigation: True
   progress bar: True
   navigation back button: false
+  question back button: True
   css:
     - https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css
     - styles.css

--- a/tests/lea-dependent-bug.spec.ts
+++ b/tests/lea-dependent-bug.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Diagnostic + regression for Lea's May-28 report: "you cannot get past the
+ * dependent page — the continue button will not work."
+ *
+ * Root cause confirmed: the docassemble app uses the default jQuery validator
+ * (`ignore: []`), which validates ALL required fields including ones hidden
+ * by `show if:`. Conditional fields without `required: False` therefore
+ * silently block Continue with no visible error — the classic project-memory
+ * "missing required:False" silent-break trap (cf. customer bugs #54/56/57 and
+ * feedback_no_hidden_validator_hack.md).
+ *
+ * The shared `clickContinue` helper overrides the validator with
+ * `ignore: ':hidden'`, which masks exactly this class of bug. This file uses
+ * a STRICT click — plain `#da-continue-button` click, no validator override —
+ * so a regression in `required: False` on a hidden conditional field would
+ * make this test hang exactly as it does for real users.
+ *
+ * Scenarios covered:
+ *   - Schedule J household_description, SINGLE filer with 0 dependents:
+ *       `other_household` is hidden via show-if:joint_case. Must have
+ *       required:False or Continue silently blocks.
+ *   - Schedule J household_description, SINGLE filer with 1 dependent:
+ *       same field hidden, must Continue through to dependent_details.
+ *   - 122A household_and_dependents_info, "Not married":
+ *       `separated_status` is hidden via show-if:filing_status. Must have
+ *       required:False or Continue silently blocks.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  b64, waitForDaPageLoad, selectYesNoRadio, fillById,
+} from './helpers';
+import {
+  navigateToDebtorPage, fillDebtorAndAdvance, passDebtorFinal,
+  navigatePropertySection, navigateExemptionSection,
+  navigateCreditorLibraryPicker, navigateSecuredCreditors,
+  navigateUnsecuredCreditors, navigateContractsLeases,
+  navigateCommunityProperty, navigateIncome,
+} from './navigation-helpers';
+
+/**
+ * STRICT Continue click: no validator override, no `:hidden` ignore.
+ * If a hidden required field exists, this will silently fail to advance —
+ * exactly as it does for a real user.
+ */
+async function clickContinueStrict(page: import('@playwright/test').Page) {
+  await waitForDaPageLoad(page);
+  await page.locator('#da-continue-button').click();
+  await page.waitForLoadState('networkidle');
+}
+
+async function getCurrentHeading(page: import('@playwright/test').Page) {
+  return (await page.locator('h1').first().textContent().catch(() => '')) || '';
+}
+
+test.describe("Lea's dependent-page bug — strict-validator regression", () => {
+  test.setTimeout(420_000);
+
+  test('household_description (single, 0 deps) Continue advances under strict validator', async ({ page }) => {
+    // Drive the interview up to Schedule J — use the shared (hack-y) clickContinue
+    // for the navigation, since we only need the strict click on the target page.
+    await navigateToDebtorPage(page, SIMPLE_SINGLE);
+    await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+    await passDebtorFinal(page);
+    await navigatePropertySection(page, SIMPLE_SINGLE);
+    await navigateExemptionSection(page);
+    await navigateCreditorLibraryPicker(page);
+    await navigateSecuredCreditors(page, SIMPLE_SINGLE);
+    await navigateUnsecuredCreditors(page, SIMPLE_SINGLE);
+    await navigateContractsLeases(page);
+    await navigateCommunityProperty(page);
+    await navigateIncome(page, SIMPLE_SINGLE);
+    await waitForDaPageLoad(page);
+
+    // Should now be on "Describe your household".
+    const heading = await getCurrentHeading(page);
+    expect(heading.toLowerCase()).toContain('household');
+
+    // Answer the only two visible required fields (single filer ⇒
+    // `other_household` is hidden by show-if:joint_case).
+    await selectYesNoRadio(page, 'debtor[0].expenses.dependents.there_are_any', false);
+    await selectYesNoRadio(page, 'debtor[0].expenses.other_people_expenses', false);
+
+    // Capture page state before strict click.
+    await page.screenshot({ path: 'test-results/strict-household-pre.png', fullPage: true });
+
+    // STRICT click — no `:hidden` validator override.
+    await clickContinueStrict(page);
+    await page.waitForTimeout(1500);
+
+    const afterHeading = await getCurrentHeading(page);
+    await page.screenshot({ path: 'test-results/strict-household-post.png', fullPage: true });
+    console.log(`[strict-0deps] post-Continue heading = "${afterHeading}"`);
+
+    // The fix is correct iff Continue advances past household_description.
+    expect(afterHeading.toLowerCase()).not.toContain('household');
+  });
+
+  test('household_description (single, 1 dep) Continue advances under strict validator', async ({ page }) => {
+    await navigateToDebtorPage(page, SIMPLE_SINGLE);
+    await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+    await passDebtorFinal(page);
+    await navigatePropertySection(page, SIMPLE_SINGLE);
+    await navigateExemptionSection(page);
+    await navigateCreditorLibraryPicker(page);
+    await navigateSecuredCreditors(page, SIMPLE_SINGLE);
+    await navigateUnsecuredCreditors(page, SIMPLE_SINGLE);
+    await navigateContractsLeases(page);
+    await navigateCommunityProperty(page);
+    await navigateIncome(page, SIMPLE_SINGLE);
+    await waitForDaPageLoad(page);
+
+    const heading = await getCurrentHeading(page);
+    expect(heading.toLowerCase()).toContain('household');
+
+    await selectYesNoRadio(page, 'debtor[0].expenses.dependents.there_are_any', true);
+    await selectYesNoRadio(page, 'debtor[0].expenses.other_people_expenses', false);
+
+    await clickContinueStrict(page);
+    await page.waitForTimeout(1500);
+
+    const afterHeading = await getCurrentHeading(page);
+    console.log(`[strict-1dep] post-Continue heading = "${afterHeading}"`);
+
+    expect(afterHeading.toLowerCase()).toContain('dependent');
+  });
+
+  // Note on 122A `separated_status`: same `show if` + missing `required: False`
+  // trap on `monthly_income.separated_status` in
+  // `122A-question-blocks.yml::household_and_dependents_info`. Fix applied
+  // defensively (identical pattern to the verified `other_household` fix above).
+  // Not driven by a runtime test here because the test path that reaches that
+  // page (non_consumer_debts=False) currently has an unrelated navigation
+  // issue on the upstream `means_test_exemptions` page — out of scope for the
+  // dependent-page fix and noted for separate investigation.
+});


### PR DESCRIPTION
## Summary

Two blockers Lea reported (May 28) against the test server.

### 1. "Cannot get past the dependent page — Continue button will not work"

Schedule J \"Describe your household\" (\`106J-question-blocks.yml::household_description\`) has \`debtor[0].expenses.other_household\` with \`show if: joint_case\` but no \`required: False\`. For single filers (the common case) the field is hidden — but the app uses the default jQuery validator (\`ignore: []\`), which validates **all** required fields including hidden ones. Continue silently blocks with no visible error. Same trap that caused customer bugs #54/56/57 (documented in \`feedback_no_hidden_validator_hack.md\`).

- **Fix**: \`required: False\` on \`other_household\` (106J).
- **Defensive same-pattern fix**: \`required: False\` on \`monthly_income.separated_status\` (122A \`household_and_dependents_info\`).

### 2. "If you accidentally select 'yes' for a secured debt, you cannot go back and change it"

\`features\` had \`navigation back button: false\` and no \`question back button: True\`, so users had **no in-page Back button** anywhere. After clicking Yes on \`prop.creditors.there_are_any\` the only way back was browser back.

- **Fix**: \`question back button: True\` in features.

## Verification

New \`tests/lea-dependent-bug.spec.ts\` uses a **strict** Continue click (no \`:hidden\` validator override) — the click pattern from \`feedback_no_hidden_validator_hack.md\` that's specifically designed to expose this bug class.

- Reverted the 106J fix and ran the strict test → it failed with heading still on \"describe your household\" (Continue silently blocked) — **bug reproduced**.
- Re-applied → both single-filer-0-deps and single-filer-1-dep paths advance correctly.
- Existing \`dependents-main-flow\` regression test still passes (2.5m).

The 122A \`separated_status\` fix is defensive — same pattern as 106J but not exercised by a runtime test here (the consumer-debts path has an unrelated upstream issue on \`means_test_exemptions\` that's out of scope).

## Out of scope but flagged

- Broader YAML audit shows **324 fields** across the questions with \`show if\` but no \`required: False\` — many latent instances of the same trap. Only the two on Lea's path are fixed here.
- Separate observation: \`means_test_exemptions\` Continue doesn't advance when all three yes/no fields are \"No\" (consumer-debts case). Existing tests use \`non_consumer_debts=true\` so they bypass it. Likely affects real users with primarily consumer debts — worth a separate investigation.

## Test plan

- [ ] Deploy to staging
- [ ] Manually verify Schedule J \"Describe your household\" Continue works for a single filer who answers Yes/No on the two visible questions
- [ ] Manually verify Back button visible on each page; click Back from a secured-debt details page and flip the gate answer to No
- [ ] Confirm with Lea that the originally-reported scenario now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)