### PR TITLE
Bulk-fix the entire silent-block Continue trap class

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -160,18 +160,22 @@ fields:
     datatype: yesno
   - Mail Address/PO Box: debtor[i].mailing_street
     show if: debtor[i].has_other_mailing_address
+    required: False
   - Mail City: debtor[i].mailing_city
     show if: debtor[i].has_other_mailing_address
+    required: False
   - Mail State: debtor[i].mailing_state
     input type: dropdown
     code: get_bk_states_list()
     datatype: str
     show if: debtor[i].has_other_mailing_address
+    required: False
   - Mail Zip: debtor[i].mailing_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: debtor[i].has_other_mailing_address
+    required: False
   - ID Type: debtor[i].tax_id.tax_id_type
     input type: radio
     choices:
@@ -181,10 +185,12 @@ fields:
     show if:
       variable: debtor[i].tax_id.tax_id_type
       is: 2
+    required: False
   - SSN: debtor[i].tax_id.tax_id
     show if:
       variable: debtor[i].tax_id.tax_id_type
       is: 1
+    required: False
   - note: |
       <script>
         // Handle dynamic county population based on state selection

--- a/docassemble/BankruptcyClinic/data/questions/103A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/103A-question-blocks.yml
@@ -82,6 +82,7 @@ fields:
   - Filing payment amount: payment.initial_payment_amount
     datatype: currency
     show if: payment.payment_on_petition
+    required: False
 ---
 id: payment_dates_add_another
 section: payment_installments

--- a/docassemble/BankruptcyClinic/data/questions/103B-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/103B-question-blocks.yml
@@ -84,6 +84,7 @@ fields:
   - Explain: family.others_with_expenses_explain
     input type: area
     show if: family.has_others_with_expenses
+    required: False
   - note: |
       <br><br>
       Does anyone other than you regularly pay any of these expenses?
@@ -92,6 +93,7 @@ fields:
   - Amount: family.other_expense_payers_amount
     datatype: number
     show if: family.has_other_expense_payers
+    required: False
   - note: |
       <br><br>
       Do you expect your average monthly expenses to increase or decrease by more than 10% during the next 6 months?
@@ -100,6 +102,7 @@ fields:
   - Explain: family.expense_changes_explain
     input type: area
     show if: family.expense_changes
+    required: False
 ---
 # Part 3 - Tell the court about your property
 table: prop_accounts_table
@@ -176,26 +179,32 @@ fields:
     default: ${ True if defined('prop.interests.gathered') and len(prop.interests) > 0 else False }
   - Address/PO Box: prop.mortgage_street
     show if: prop.has_home
+    required: False
     default: ${ prop.interests[0].street if defined('prop.interests.gathered') and len(prop.interests) > 0 and hasattr(prop.interests[0], 'street') else '' }
   - City: prop.mortgage_city
     show if: prop.has_home
+    required: False
     default: ${ prop.interests[0].city if defined('prop.interests.gathered') and len(prop.interests) > 0 and hasattr(prop.interests[0], 'city') else '' }
   - State: prop.mortgage_state
     show if: prop.has_home
+    required: False
     default: ${ prop.interests[0].state if defined('prop.interests.gathered') and len(prop.interests) > 0 and hasattr(prop.interests[0], 'state') else '' }
   - Zip: prop.mortgage_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: prop.has_home
+    required: False
     default: ${ prop.interests[0].zip if defined('prop.interests.gathered') and len(prop.interests) > 0 and hasattr(prop.interests[0], 'zip') else '' }
   - Current Value: prop.mortgage_current_value
     datatype: currency
     show if: prop.has_home
+    required: False
     default: ${ prop.interests[0].current_value if defined('prop.interests.gathered') and len(prop.interests) > 0 and hasattr(prop.interests[0], 'current_value') else 0 }
   - Amount owed: prop.mortgage_amount_owed
     datatype: currency
     show if: prop.has_home
+    required: False
     default: ${ prop.interests[0].current_owed_amount if defined('prop.interests.gathered') and len(prop.interests) > 0 and hasattr(prop.interests[0], 'current_owed_amount') else 0 }
 validation code: |
   # Issue #77: hard-block fee-waiver real-estate value if it diverges significantly
@@ -224,26 +233,32 @@ fields:
     default: ${ True if defined('prop.interests.gathered') and len(prop.interests) > 1 else False }
   - Address/PO Box: prop.other_mortgage_street
     show if: prop.has_other_real_estate
+    required: False
     default: ${ prop.interests[1].street if defined('prop.interests.gathered') and len(prop.interests) > 1 and hasattr(prop.interests[1], 'street') else '' }
   - City: prop.other_mortgage_city
     show if: prop.has_other_real_estate
+    required: False
     default: ${ prop.interests[1].city if defined('prop.interests.gathered') and len(prop.interests) > 1 and hasattr(prop.interests[1], 'city') else '' }
   - State: prop.other_mortgage_state
     show if: prop.has_other_real_estate
+    required: False
     default: ${ prop.interests[1].state if defined('prop.interests.gathered') and len(prop.interests) > 1 and hasattr(prop.interests[1], 'state') else '' }
   - Zip: prop.other_mortgage_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: prop.has_other_real_estate
+    required: False
     default: ${ prop.interests[1].zip if defined('prop.interests.gathered') and len(prop.interests) > 1 and hasattr(prop.interests[1], 'zip') else '' }
   - Current Value: prop.other_mortgage_current_value
     datatype: currency
     show if: prop.has_other_real_estate
+    required: False
     default: ${ prop.interests[1].current_value if defined('prop.interests.gathered') and len(prop.interests) > 1 and hasattr(prop.interests[1], 'current_value') else 0 }
   - Amount owed: prop.other_mortgage_amount_owed
     datatype: currency
     show if: prop.has_other_real_estate
+    required: False
     default: ${ prop.interests[1].current_owed_amount if defined('prop.interests.gathered') and len(prop.interests) > 1 and hasattr(prop.interests[1], 'current_owed_amount') else 0 }
 ---
 table: prop_vehicles_table
@@ -380,11 +395,14 @@ fields:
       - A bankruptcy petition preparer, paralegal, or typing service
       - Someone else
     show if: additional.paid_for_services
+    required: False
   - Describe who: additional.paid_for_services_who_describe
     show if: additional.paid_for_services
+    required: False
   - How much?: additional.paid_for_services_amount
     datatype: currency
     show if: additional.paid_for_services
+    required: False
   - note: |
       <br><br>
       Have you promised to pay or do you expect to pay someone for services for your bankruptcy case?
@@ -397,11 +415,14 @@ fields:
       - A bankruptcy petition preparer, paralegal, or typing service
       - Someone else
     show if: additional.promised_for_services
+    required: False
   - Describe who: additional.promised_for_services_who_describe
     show if: additional.promised_for_services
+    required: False
   - How much?: additional.promised_for_services_amount
     datatype: currency
     show if: additional.promised_for_services
+    required: False
   - note: |
       <br><br>
       Has anyone paid someone on your behalf for services for this case?
@@ -414,6 +435,7 @@ fields:
       - A bankruptcy petition preparer, paralegal, or typing service
       - Someone else
     show if: additional.behalf_for_services
+    required: False
   - Who paid?: additional.behalf_for_services_paid
     datatype: checkboxes
     choices:
@@ -423,11 +445,14 @@ fields:
       - Pastor or clergy
       - Someone else
     show if: additional.behalf_for_services
+    required: False
   - Other payer: additional.behalf_other_payer
     show if: additional.behalf_for_services
+    required: False
   - How much was paid?: additional.behalf_for_services_amount
     datatype: currency
     show if: additional.behalf_for_services
+    required: False
 ---
 table: add_bankruptcy_table
 rows: additional.bankruptcies

--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -155,6 +155,7 @@ fields:
       - Other
   - Other property type: prop.interests[i].other_type
     show if: prop.interests[i].type["Other"]
+    required: False
   - Who has an interest in the property?: prop.interests[i].who
     input type: radio
     choices:
@@ -173,6 +174,7 @@ fields:
   - How much do you owe on the loan?: prop.interests[i].current_owed_amount
     datatype: currency
     show if: prop.interests[i].has_loan
+    required: False
   - Describe the nature of your ownership interest: prop.interests[i].ownership_interest
     datatype: combobox
     choices:
@@ -196,12 +198,14 @@ fields:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'real_property')
     show if: prop.interests[i].is_claiming_exemption
+    required: False
   - Amount you're claiming as exempt: prop.interests[i].exemption_value
     datatype: currency
     help: |
       Enter the value you're claiming as exempt — the full owned value to claim
       100% of fair market value, or a smaller dollar amount for a partial claim.
     show if: prop.interests[i].is_claiming_exemption
+    required: False
   - note: Second exemption (optional — only if a second law also applies)
     show if: prop.interests[i].is_claiming_exemption
   - Specific laws that allow exemption (second): prop.interests[i].exemption_laws_2
@@ -324,6 +328,7 @@ fields:
   - How much do you owe on the loan?: prop.ab_vehicles[i].current_owed_amount
     datatype: currency
     show if: prop.ab_vehicles[i].has_loan
+    required: False
   - Is this community property?: prop.ab_vehicles[i].is_community_property
     datatype: yesnoradio
   - Other information: prop.ab_vehicles[i].other_info
@@ -342,6 +347,7 @@ fields:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'vehicle')
     show if: prop.ab_vehicles[i].is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.ab_vehicles[i].is_claiming_exemption
   - Value of exemption being claimed: prop.ab_vehicles[i].exemption_value_2
@@ -450,6 +456,7 @@ fields:
   - How much do you owe on the loan?: prop.ab_other_vehicles[i].current_owed_amount
     datatype: currency
     show if: prop.ab_other_vehicles[i].has_loan
+    required: False
   - Is this community property?: prop.ab_other_vehicles[i].is_community_property
     datatype: yesnoradio
   - Claiming Exemption?: prop.ab_other_vehicles[i].is_claiming_exemption
@@ -459,11 +466,13 @@ fields:
   - Value of exemption being claimed: prop.ab_other_vehicles[i].exemption_value
     datatype: currency
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.ab_other_vehicles[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'vehicle')
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
+    required: False
   - note: Exemption 2
     show if: prop.ab_other_vehicles[i].is_claiming_exemption
   - Value of exemption being claimed: prop.ab_other_vehicles[i].exemption_value_2
@@ -593,22 +602,27 @@ fields:
   - Describe: prop.household_goods_description
     input type: area
     show if: prop.has_household_goods
+    required: False
   - Total owned value: prop.household_goods_value
     datatype: currency
     show if: prop.has_household_goods
+    required: False
   - Claiming Exemption?: prop.household_goods_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_household_goods
+    required: False
   - note: Exemption 1
     show if: prop.household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.household_goods_exemption_value
     datatype: currency
     show if: prop.household_goods_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.household_goods_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'household_goods')
     show if: prop.household_goods_is_claiming_exemption
+    required: False
   - note: Exemption 2
     show if: prop.household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.household_goods_exemption_value_2
@@ -629,22 +643,27 @@ fields:
   - Describe: prop.secured_household_goods_description
     input type: area
     show if: prop.has_secured_household_goods
+    required: False
   - Total owned value: prop.secured_household_goods_value
     datatype: currency
     show if: prop.has_secured_household_goods
+    required: False
   - Claiming Exemption?: prop.secured_household_goods_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_secured_household_goods
+    required: False
   - note: Exemption 1
     show if: prop.secured_household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.secured_household_goods_exemption_value
     datatype: currency
     show if: prop.secured_household_goods_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.secured_household_goods_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'household_goods')
     show if: prop.secured_household_goods_is_claiming_exemption
+    required: False
   - note: Exemption 2
     show if: prop.secured_household_goods_is_claiming_exemption
   - Value of exemption being claimed: prop.secured_household_goods_exemption_value_2
@@ -665,22 +684,27 @@ fields:
   - Describe: prop.electronics_description
     input type: area
     show if: prop.has_electronics
+    required: False
   - Total owned value: prop.electronics_value
     datatype: currency
     show if: prop.has_electronics
+    required: False
   - Claiming Exemption?: prop.electronics_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_electronics
+    required: False
   - note: First Exemption
     show if: prop.electronics_is_claiming_exemption
   - Value of exemption being claimed: prop.electronics_exemption_value
     datatype: currency
     show if: prop.electronics_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.electronics_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'electronics')
     show if: prop.electronics_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.electronics_is_claiming_exemption
   - Value of exemption being claimed: prop.electronics_exemption_value_2
@@ -701,22 +725,27 @@ fields:
   - Describe: prop.collectibles_description
     input type: area
     show if: prop.has_collectibles
+    required: False
   - Total owned value: prop.collectibles_value
     datatype: currency
     show if: prop.has_collectibles
+    required: False
   - Claiming Exemption?: prop.collectibles_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_collectibles
+    required: False
   - note: First Exemption
     show if: prop.collectibles_is_claiming_exemption
   - Value of exemption being claimed: prop.collectibles_exemption_value
     datatype: currency
     show if: prop.collectibles_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.collectibles_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.collectibles_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.collectibles_is_claiming_exemption
   - Value of exemption being claimed: prop.collectibles_exemption_value_2
@@ -737,22 +766,27 @@ fields:
   - Describe: prop.hobby_equipment_description
     input type: area
     show if: prop.has_hobby_equipment
+    required: False
   - Total owned value: prop.hobby_equipment_value
     datatype: currency
     show if: prop.has_hobby_equipment
+    required: False
   - Claiming Exemption?: prop.hobby_equipment_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_hobby_equipment
+    required: False
   - note: First Exemption
     show if: prop.hobby_equipment_is_claiming_exemption
   - Value of exemption being claimed: prop.hobby_equipment_exemption_value
     datatype: currency
     show if: prop.hobby_equipment_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.hobby_equipment_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.hobby_equipment_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.hobby_equipment_is_claiming_exemption
   - Value of exemption being claimed: prop.hobby_equipment_exemption_value_2
@@ -773,22 +807,27 @@ fields:
   - Describe: prop.firearms_description
     input type: area
     show if: prop.has_firearms
+    required: False
   - Total owned value: prop.firearms_value
     datatype: currency
     show if: prop.has_firearms
+    required: False
   - Claiming Exemption?: prop.firearms_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_firearms
+    required: False
   - note: First Exemption
     show if: prop.firearms_is_claiming_exemption
   - Value of exemption being claimed: prop.firearms_exemption_value
     datatype: currency
     show if: prop.firearms_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.firearms_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.firearms_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.firearms_is_claiming_exemption
   - Value of exemption being claimed: prop.firearms_exemption_value_2
@@ -809,22 +848,27 @@ fields:
   - Describe: prop.clothes_description
     input type: area
     show if: prop.has_clothes
+    required: False
   - Total owned value: prop.clothes_value
     datatype: currency
     show if: prop.has_clothes
+    required: False
   - Claiming Exemption?: prop.clothes_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_clothes
+    required: False
   - note: First Exemption
     show if: prop.clothes_is_claiming_exemption
   - Value of exemption being claimed: prop.clothes_exemption_value
     datatype: currency
     show if: prop.clothes_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.clothes_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'clothes')
     show if: prop.clothes_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.clothes_is_claiming_exemption
   - Value of exemption being claimed: prop.clothes_exemption_value_2
@@ -845,22 +889,27 @@ fields:
   - Describe: prop.jewelry_description
     input type: area
     show if: prop.has_jewelry
+    required: False
   - Total owned value: prop.jewelry_value
     datatype: currency
     show if: prop.has_jewelry
+    required: False
   - Claiming Exemption?: prop.jewelry_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_jewelry
+    required: False
   - note: First Exemption
     show if: prop.jewelry_is_claiming_exemption
   - Value of exemption being claimed: prop.jewelry_exemption_value
     datatype: currency
     show if: prop.jewelry_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.jewelry_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'jewelry')
     show if: prop.jewelry_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.jewelry_is_claiming_exemption
   - Value of exemption being claimed: prop.jewelry_exemption_value_2
@@ -881,22 +930,27 @@ fields:
   - Describe: prop.animal_description
     input type: area
     show if: prop.has_animals
+    required: False
   - Total owned value: prop.animal_value
     datatype: currency
     show if: prop.has_animals
+    required: False
   - Claiming Exemption?: prop.animal_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_animals
+    required: False
   - note: First Exemption
     show if: prop.animal_is_claiming_exemption
   - Value of exemption being claimed: prop.animal_exemption_value
     datatype: currency
     show if: prop.animal_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.animal_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.animal_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.animal_is_claiming_exemption
   - Value of exemption being claimed: prop.animal_exemption_value_2
@@ -917,22 +971,27 @@ fields:
   - Describe: prop.other_household_items_description
     input type: area
     show if: prop.has_other_household_items
+    required: False
   - Total owned value: prop.other_household_items_value
     datatype: currency
     show if: prop.has_other_household_items
+    required: False
   - Claiming Exemption?: prop.other_household_items_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.has_other_household_items
+    required: False
   - note: First Exemption
     show if: prop.other_household_items_is_claiming_exemption
   - Value of exemption being claimed: prop.other_household_items_exemption_value
     datatype: currency
     show if: prop.other_household_items_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.other_household_items_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'other_household_items')
     show if: prop.other_household_items_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.other_household_items_is_claiming_exemption
   - Value of exemption being claimed: prop.other_household_items_exemption_value_2
@@ -980,19 +1039,23 @@ fields:
   - Total value: prop.financial_assets.cash_value
     datatype: currency
     show if: prop.financial_assets.has_cash
+    required: False
   - Claiming Exemption?: prop.financial_assets.cash_is_claiming_exemption
     datatype: yesnoradio
     show if: prop.financial_assets.has_cash
+    required: False
   - note: First Exemption
     show if: prop.financial_assets.cash_is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.cash_exemption_value
     datatype: currency
     show if: prop.financial_assets.cash_is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.cash_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'cash')
     show if: prop.financial_assets.cash_is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.cash_is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.cash_exemption_value_2
@@ -1076,11 +1139,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.deposits[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.deposits[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.deposits[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.deposits[i].exemption_value_2
@@ -1157,11 +1222,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.bonds_and_stocks[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.bonds_and_stocks[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.bonds_and_stocks[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.bonds_and_stocks[i].exemption_value_2
@@ -1242,11 +1309,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.non_traded_stock[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.non_traded_stock[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.non_traded_stock[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.non_traded_stock[i].exemption_value_2
@@ -1323,11 +1392,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.corporate_bonds[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.corporate_bonds[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.corporate_bonds[i].is_claiming_exemption
   - Value of exemption being claimed: prop.financial_assets.corporate_bonds[i].exemption_value_2
@@ -1415,11 +1486,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.retirement_accounts[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.retirement_accounts[i].has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.retirement_accounts[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'retirement')
     show if: prop.financial_assets.retirement_accounts[i].has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.retirement_accounts[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.retirement_accounts[i].exemption_value_2
@@ -1510,11 +1583,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.prepayments[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.prepayments[i].has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.prepayments[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.prepayments[i].has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.prepayments[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.prepayments[i].exemption_value_2
@@ -1592,11 +1667,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.annuities[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.annuities[i].has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.annuities[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.financial_assets.annuities[i].has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.annuities[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.annuities[i].exemption_value_2
@@ -1674,11 +1751,13 @@ fields:
   - Value of exemption being claimed: prop.financial_assets.edu_accounts[i].exemption_value
     datatype: currency
     show if: prop.financial_assets.edu_accounts[i].has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.edu_accounts[i].exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'edu_accounts')
     show if: prop.financial_assets.edu_accounts[i].has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.edu_accounts[i].has_claim
   - Value of exemption being claimed: prop.financial_assets.edu_accounts[i].exemption_value_2
@@ -1723,22 +1802,27 @@ fields:
   - Describe interest: prop.financial_assets.future_property_interest_description
     input type: area
     show if: prop.financial_assets.has_future_property_interest
+    required: False
   - Interest value: prop.financial_assets.future_property_interest_value
     datatype: currency
     show if: prop.financial_assets.has_future_property_interest
+    required: False
   - Claiming Exemption?: prop.financial_assets.future_property_interest_has_claim
     datatype: yesnoradio
     show if: prop.financial_assets.has_future_property_interest
+    required: False
   - note: First Exemption
     show if: prop.financial_assets.future_property_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.future_property_interest_exemption_value
     datatype: currency
     show if: prop.financial_assets.future_property_interest_has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.future_property_interest_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.future_property_interest_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.future_property_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.future_property_interest_exemption_value_2
@@ -1784,22 +1868,27 @@ fields:
   - Describe IP: prop.financial_assets.ip_interest_description
     input type: area
     show if: prop.financial_assets.has_ip_interest
+    required: False
   - IP value: prop.financial_assets.ip_interest_value
     datatype: currency
     show if: prop.financial_assets.has_ip_interest
+    required: False
   - Claiming Exemption?: prop.financial_assets.ip_interest_has_claim
     datatype: yesnoradio
     show if: prop.financial_assets.has_ip_interest
+    required: False
   - note: First Exemption
     show if: prop.financial_assets.ip_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.ip_interest_exemption_value
     datatype: currency
     show if: prop.financial_assets.ip_interest_has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.ip_interest_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.ip_interest_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.ip_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.ip_interest_exemption_value_2
@@ -1844,22 +1933,27 @@ fields:
   - Describe interest: prop.financial_assets.intangible_interest_description
     input type: area
     show if: prop.financial_assets.has_intangible_interest
+    required: False
   - Interest value: prop.financial_assets.intangible_interest_value
     datatype: currency
     show if: prop.financial_assets.has_intangible_interest
+    required: False
   - Claiming Exemption?: prop.financial_assets.intangible_interest_has_claim
     datatype: yesnoradio
     show if: prop.financial_assets.has_intangible_interest
+    required: False
   - note: First Exemption
     show if: prop.financial_assets.intangible_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.intangible_interest_exemption_value
     datatype: currency
     show if: prop.financial_assets.intangible_interest_has_claim
+    required: False
   - Specific laws that allow exemption: prop.financial_assets.intangible_interest_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.financial_assets.intangible_interest_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.financial_assets.intangible_interest_has_claim
   - Value of exemption being claimed: prop.financial_assets.intangible_interest_exemption_value_2
@@ -1995,6 +2089,7 @@ fields:
   - Give specific information about them: prop.owed_property.tax_refund_description
     input type: area
     show if: prop.owed_property.has_tax_refund
+    required: False
   - Federal amount: prop.owed_property.tax_refund_federal
     datatype: currency
     show if: prop.owed_property.has_tax_refund
@@ -2013,12 +2108,14 @@ fields:
     show if: prop.owed_property.tax_refund_has_claim
   - Value of exemption being claimed: prop.owed_property.tax_refund_exemption_value
     show if: prop.owed_property.tax_refund_has_claim
+    required: False
     datatype: currency
   - Specific laws that allow exemption: prop.owed_property.tax_refund_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'tax_refund')
     show if: prop.owed_property.tax_refund_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.tax_refund_has_claim
   - Value of exemption being claimed: prop.owed_property.tax_refund_exemption_value_2
@@ -2069,11 +2166,13 @@ fields:
   - Value of exemption being claimed: prop.owed_property.family_support_exemption_value
     datatype: currency
     show if: prop.owed_property.family_support_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.family_support_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.owed_property.family_support_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.family_support_has_claim
   - Value of exemption being claimed: prop.owed_property.family_support_exemption_value_2
@@ -2109,11 +2208,13 @@ fields:
   - Value of exemption being claimed: prop.owed_property.other_amounts_exemption_value
     datatype: currency
     show if: prop.owed_property.other_amounts_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.other_amounts_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wages')
     show if: prop.owed_property.other_amounts_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.other_amounts_has_claim
   - Value of exemption being claimed: prop.owed_property.other_amounts_exemption_value_2
@@ -2153,11 +2254,13 @@ fields:
   - Value of exemption being claimed: prop.owed_property.first_insurance_interest_exemption_value
     datatype: currency
     show if: prop.owed_property.first_insurance_interest_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.first_insurance_interest_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.first_insurance_interest_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.first_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.first_insurance_interest_exemption_value_2
@@ -2176,6 +2279,7 @@ fields:
   - Has second insurance interest: prop.owed_property.has_second_insurance_interest
     datatype: yesnoradio
     show if: prop.owed_property.has_insurance_interest
+    required: False
   - Institution name: prop.owed_property.second_insurance_interest_name
     required: False
     show if: prop.owed_property.has_second_insurance_interest
@@ -2189,16 +2293,19 @@ fields:
   - Claiming Exemption?: prop.owed_property.second_insurance_interest_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_second_insurance_interest
+    required: False
   - note: First Exemption
     show if: prop.owed_property.second_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.second_insurance_interest_exemption_value
     datatype: currency
     show if: prop.owed_property.second_insurance_interest_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.second_insurance_interest_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.second_insurance_interest_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.second_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.second_insurance_interest_exemption_value_2
@@ -2217,6 +2324,7 @@ fields:
   - Has third insurance interest: prop.owed_property.has_third_insurance_interest
     datatype: yesnoradio
     show if: prop.owed_property.has_insurance_interest
+    required: False
   - Institution name: prop.owed_property.third_insurance_interest_name
     required: False
     show if: prop.owed_property.has_third_insurance_interest
@@ -2230,16 +2338,19 @@ fields:
   - Claiming Exemption?: prop.owed_property.third_insurance_interest_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_third_insurance_interest
+    required: False
   - note: First Exemption
     show if: prop.owed_property.third_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.third_insurance_interest_exemption_value
     datatype: currency
     show if: prop.owed_property.third_insurance_interest_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.third_insurance_interest_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'insurance')
     show if: prop.owed_property.third_insurance_interest_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.third_insurance_interest_has_claim
   - Value of exemption being claimed: prop.owed_property.third_insurance_interest_exemption_value_2
@@ -2271,16 +2382,19 @@ fields:
   - Claiming Exemption?: prop.owed_property.trust_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_trust
+    required: False
   - note: First Exemption
     show if: prop.owed_property.trust_has_claim
   - Value of exemption being claimed: prop.owed_property.trust_exemption_value
     datatype: currency
     show if: prop.owed_property.trust_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.trust_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'trust')
     show if: prop.owed_property.trust_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.trust_has_claim
   - Value of exemption being claimed: prop.owed_property.trust_exemption_value_2
@@ -2312,16 +2426,19 @@ fields:
   - Claiming Exemption?: prop.owed_property.third_party_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_third_party
+    required: False
   - note: First Exemption
     show if: prop.owed_property.third_party_has_claim
   - Value of exemption being claimed: prop.owed_property.third_party_exemption_value
     datatype: currency
     show if: prop.owed_property.third_party_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.third_party_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'third_party')
     show if: prop.owed_property.third_party_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.third_party_has_claim
   - Value of exemption being claimed: prop.owed_property.third_party_exemption_value_2
@@ -2351,16 +2468,19 @@ fields:
   - Claiming Exemption?: prop.owed_property.contingent_claims_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_contingent_claims
+    required: False
   - note: First Exemption
     show if: prop.owed_property.contingent_claims_has_claim
   - Value of exemption being claimed: prop.owed_property.contingent_claims_exemption_value
     datatype: currency
     show if: prop.owed_property.contingent_claims_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.contingent_claims_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'contingent_claims')
     show if: prop.owed_property.contingent_claims_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.contingent_claims_has_claim
   - Value of exemption being claimed: prop.owed_property.contingent_claims_exemption_value_2
@@ -2391,16 +2511,19 @@ fields:
   - Claiming Exemption?: prop.owed_property.other_assets_has_claim
     datatype: yesnoradio
     show if: prop.owed_property.has_other_assets
+    required: False
   - note: First Exemption
     show if: prop.owed_property.other_assets_has_claim
   - Value of exemption being claimed: prop.owed_property.other_assets_exemption_value
     datatype: currency
     show if: prop.owed_property.other_assets_has_claim
+    required: False
   - Specific laws that allow exemption: prop.owed_property.other_assets_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.owed_property.other_assets_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.owed_property.other_assets_has_claim
   - Value of exemption being claimed: prop.owed_property.other_assets_exemption_value_2
@@ -2525,11 +2648,13 @@ fields:
   - Value of exemption being claimed: prop.business_property.ar_exemption_value
     datatype: currency
     show if: prop.business_property.ar_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.ar_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.ar_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.ar_has_claim
   - Value of exemption being claimed: prop.business_property.ar_exemption_value_2
@@ -2565,11 +2690,13 @@ fields:
   - Value of exemption being claimed: prop.business_property.equipment_exemption_value
     datatype: currency
     show if: prop.business_property.equipment_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.equipment_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_equipment')
     show if: prop.business_property.equipment_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.equipment_has_claim
   - Value of exemption being claimed: prop.business_property.equipment_exemption_value_2
@@ -2604,11 +2731,13 @@ fields:
   - Value of exemption being claimed: prop.business_property.machinery_exemption_value
     datatype: currency
     show if: prop.business_property.machinery_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.machinery_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_equipment')
     show if: prop.business_property.machinery_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.machinery_has_claim
   - Value of exemption being claimed: prop.business_property.machinery_exemption_value_2
@@ -2642,11 +2771,13 @@ fields:
   - Value of exemption being claimed: prop.business_property.inventory_exemption_value
     datatype: currency
     show if: prop.business_property.inventory_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.inventory_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.inventory_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.inventory_has_claim
   - Value of exemption being claimed: prop.business_property.inventory_exemption_value_2
@@ -2723,16 +2854,19 @@ fields:
   - Claiming Exemption?: prop.business_property.partnership_has_claim
     datatype: yesnoradio
     show if: prop.business_property.has_partnerships
+    required: False
   - note: First Exemption
     show if: prop.business_property.partnership_has_claim
   - Value of exemption being claimed: prop.business_property.partnership_exemption_value
     datatype: currency
     show if: prop.business_property.partnership_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.partnership_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.partnership_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.partnership_has_claim
   - Value of exemption being claimed: prop.business_property.partnership_exemption_value_2
@@ -2770,11 +2904,13 @@ fields:
   - Value of exemption being claimed: prop.business_property.lists_exemption_value
     datatype: currency
     show if: prop.business_property.lists_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.lists_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.lists_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.lists_has_claim
   - Value of exemption being claimed: prop.business_property.lists_exemption_value_2
@@ -2838,16 +2974,19 @@ fields:
   - Claiming Exemption?: prop.business_property.otherProperty_has_claim
     datatype: yesnoradio
     show if: prop.business_property.has_other
+    required: False
   - note: First Exemption
     show if: prop.business_property.otherProperty_has_claim
   - Value of exemption being claimed: prop.business_property.otherProperty_exemption_value
     datatype: currency
     show if: prop.business_property.otherProperty_has_claim
+    required: False
   - Specific laws that allow exemption: prop.business_property.otherProperty_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'business_other')
     show if: prop.business_property.otherProperty_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.business_property.otherProperty_has_claim
   - Value of exemption being claimed: prop.business_property.otherProperty_exemption_value_2
@@ -2953,11 +3092,13 @@ fields:
   - Value of exemption being claimed: prop.farming_property.animal_exemption_value
     datatype: currency
     show if: prop.farming_property.has_animal_claim
+    required: False
   - Specific laws that allow exemption: prop.farming_property.animal_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_animal_claim
+    required: False
   - note: Second Exemption
     show if: prop.farming_property.has_animal_claim
   - Value of exemption being claimed: prop.farming_property.animal_exemption_value_2
@@ -2991,11 +3132,13 @@ fields:
   - Value of exemption being claimed: prop.farming_property.crops_exemption_value
     datatype: currency
     show if: prop.farming_property.has_crops_claim
+    required: False
   - Specific laws that allow exemption: prop.farming_property.crops_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_crops_claim
+    required: False
   - note: Second Exemption
     show if: prop.farming_property.has_crops_claim
   - Value of exemption being claimed: prop.farming_property.crops_exemption_value_2
@@ -3028,11 +3171,13 @@ fields:
   - Value of exemption being claimed: prop.farming_property.equipment_exemption_value
     datatype: currency
     show if: prop.farming_property.has_equipment_claim
+    required: False
   - Specific laws that allow exemption: prop.farming_property.equipment_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_equipment_claim
+    required: False
   - note: Second Exemption
     show if: prop.farming_property.has_equipment_claim
   - Value of exemption being claimed: prop.farming_property.equipment_exemption_value_2
@@ -3065,11 +3210,13 @@ fields:
   - Value of exemption being claimed: prop.farming_property.supplies_exemption_value
     datatype: currency
     show if: prop.farming_property.has_supplies_claim
+    required: False
   - Specific laws that allow exemption: prop.farming_property.supplies_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_supplies_claim
+    required: False
   - note: Second Exemption
     show if: prop.farming_property.has_supplies_claim
   - Value of exemption being claimed: prop.farming_property.supplies_exemption_value_2
@@ -3103,11 +3250,13 @@ fields:
   - Value of exemption being claimed: prop.farming_property.fishing_exemption_value
     datatype: currency
     show if: prop.farming_property.has_fishing_claim
+    required: False
   - Specific laws that allow exemption: prop.farming_property.fishing_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.farming_property.has_fishing_claim
+    required: False
   - note: Second Exemption
     show if: prop.farming_property.has_fishing_claim
   - Value of exemption being claimed: prop.farming_property.fishing_exemption_value_2
@@ -3163,6 +3312,7 @@ fields:
   - Has second unlisted property?: prop.has_second_other_prop
     datatype: yesnoradio
     show if: prop.has_other_prop
+    required: False
   - Property value: prop.other_prop_value2
     datatype: currency
     required: False
@@ -3170,6 +3320,7 @@ fields:
   - Has third unlisted property?: prop.has_third_other_prop
     datatype: yesnoradio
     show if: prop.has_other_prop
+    required: False
   - Property value: prop.other_prop_value3
     datatype: currency
     required: False
@@ -3181,11 +3332,13 @@ fields:
   - Value of exemption being claimed: prop.other_prop_exemption_value
     datatype: currency
     show if: prop.other_prop_has_claim
+    required: False
   - Specific laws that allow exemption: prop.other_prop_exemption_laws
     choices:
       code: |
         get_exemption_choices_or_combined(exemption_filing_state,'wildcard_only')
     show if: prop.other_prop_has_claim
+    required: False
   - note: Second Exemption
     show if: prop.other_prop_has_claim
   - Value of exemption being claimed: prop.other_prop_exemption_value_2

--- a/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
@@ -102,18 +102,22 @@ fields:
     show if:
       variable: prop.priority_claims[i].has_codebtor
       is: True
+    required: False
   - Address/PO Box: prop.priority_claims[i].codebtor_street
     show if:
       variable: prop.priority_claims[i].has_codebtor
       is: True
+    required: False
   - City: prop.priority_claims[i].codebtor_city
     show if:
       variable: prop.priority_claims[i].has_codebtor
       is: True
+    required: False
   - State: prop.priority_claims[i].codebtor_state
     show if:
       variable: prop.priority_claims[i].has_codebtor
       is: True
+    required: False
   - Zip: prop.priority_claims[i].codebtor_zip
     datatype: text
     minlength: 5
@@ -122,6 +126,7 @@ fields:
       variable: prop.priority_claims[i].has_codebtor
       is: True
 
+    required: False
   - Do others need to be notified about this debt?: prop.priority_claims[i].has_notify
     datatype: yesnoradio
 
@@ -359,18 +364,22 @@ fields:
     show if:
       variable: prop.nonpriority_claims[i].has_codebtor
       is: True
+    required: False
   - Address/PO Box: prop.nonpriority_claims[i].codebtor_street
     show if:
       variable: prop.nonpriority_claims[i].has_codebtor
       is: True
+    required: False
   - City: prop.nonpriority_claims[i].codebtor_city
     show if:
       variable: prop.nonpriority_claims[i].has_codebtor
       is: True
+    required: False
   - State: prop.nonpriority_claims[i].codebtor_state
     show if:
       variable: prop.nonpriority_claims[i].has_codebtor
       is: True
+    required: False
   - Zip: prop.nonpriority_claims[i].codebtor_zip
     datatype: text
     minlength: 5
@@ -379,6 +388,7 @@ fields:
       variable: prop.nonpriority_claims[i].has_codebtor
       is: True
 
+    required: False
   - Do others need to be notified about this debt?: prop.nonpriority_claims[i].has_notify
     datatype: yesnoradio
 

--- a/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
@@ -78,7 +78,7 @@ fields:
       - Claim for death or personal injury while you were intoxicated: Claims for death or personal injury while you were intoxicated
       - Other priority debt: Other
   - Specify other unsecured claim type: prop.priority_claims[i].other_type
-    required: True
+    required: False
     show if:
       variable: prop.priority_claims[i].type
       is: Other
@@ -344,7 +344,7 @@ fields:
       - Contract
       - Other
   - Specify other unsecured claim type: prop.nonpriority_claims[i].other_type
-    required: True
+    required: False
     show if:
       variable: prop.nonpriority_claims[i].type
       is: Other

--- a/docassemble/BankruptcyClinic/data/questions/106G-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106G-question-blocks.yml
@@ -47,18 +47,22 @@ fields:
     show if:
       variable: prop.contracts_and_leases[i].has_codebtor
       is: True
+    required: False
   - Address/PO Box: prop.contracts_and_leases[i].codebtor_street
     show if:
       variable: prop.contracts_and_leases[i].has_codebtor
       is: True
+    required: False
   - City: prop.contracts_and_leases[i].codebtor_city
     show if:
       variable: prop.contracts_and_leases[i].has_codebtor
       is: True
+    required: False
   - State: prop.contracts_and_leases[i].codebtor_state
     show if:
       variable: prop.contracts_and_leases[i].has_codebtor
       is: True
+    required: False
   - Zip: prop.contracts_and_leases[i].codebtor_zip
     datatype: text
     minlength: 5
@@ -66,11 +70,13 @@ fields:
     show if:
       variable: prop.contracts_and_leases[i].has_codebtor
       is: True
+    required: False
   - Is this an unexpired lease?: prop.contracts_and_leases[i].unexpired_lease
     datatype: yesnoradio
   - Will the lease be assumed?: prop.contracts_and_leases[i].lease_assumed
     datatype: yesnoradio
     show if: prop.contracts_and_leases[i].unexpired_lease
+    required: False
 list collect: True
 ---
 id: schedule_g_review

--- a/docassemble/BankruptcyClinic/data/questions/106I-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106I-question-blocks.yml
@@ -13,10 +13,12 @@ fields:
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
   - Employer Name: debtor[0].income.employer
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
   - note: Employer Address
     show if:
       variable: debtor[0].income.employment
@@ -25,14 +27,17 @@ fields:
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
   - City: debtor[0].income.employer_city
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
   - State: debtor[0].income.employer_state
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
   - Zip: debtor[0].income.employer_zip
     datatype: text
     minlength: 5
@@ -40,10 +45,12 @@ fields:
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
   - How long employed there?: debtor[0].income.employment_length
     show if:
       variable: debtor[0].income.employment
       is: Employed
+    required: False
 ---
 id: debtor1_monthly_income_details
 section: schedule_i
@@ -286,10 +293,12 @@ fields:
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
   - Employer Name: debtor[1].income.employer
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
   - note: Employer Address
     show if:
       variable: debtor[1].income.employment
@@ -298,14 +307,17 @@ fields:
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
   - City: debtor[1].income.employer_city
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
   - State: debtor[1].income.employer_state
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
   - Zip: debtor[1].income.employer_zip
     datatype: text
     minlength: 5
@@ -313,10 +325,12 @@ fields:
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
   - How long employed there?: debtor[1].income.employment_length
     show if:
       variable: debtor[1].income.employment
       is: Employed
+    required: False
 ---
 id: debtor2_monthly_income_details
 section: schedule_i
@@ -542,9 +556,11 @@ fields:
     datatype: yesnoradio
   - Specify: debtor[0].income.specify_other_regular_contributions
     show if: debtor[0].income.other_regular_contributions
+    required: False
   - Amount: debtor[0].income.other_regular_contributions_amount
     datatype: currency
     show if: debtor[0].income.other_regular_contributions
+    required: False
   - Do you expect an increase or decrease of income within the year after you file this form?: debtor[0].income.expect_year_delta
     datatype: yesnoradio
   - Explain any changes or other notes: debtor[0].income.year_delta_explain

--- a/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
@@ -68,6 +68,7 @@ fields:
     show if:
       code: |
         financial_affairs.debtor_count > 1
+    required: False
     hide if:
       variable: financial_affairs.lived_elsewhere
       is: False
@@ -75,6 +76,7 @@ fields:
     show if:
       code: |
         financial_affairs.debtor_count > 1
+    required: False
     hide if:
       variable: financial_affairs.address_same_1
       is: True
@@ -82,6 +84,7 @@ fields:
     show if:
       code: |
         financial_affairs.debtor_count > 1
+    required: False
     hide if:
       variable: financial_affairs.address_same_1
       is: True
@@ -89,6 +92,7 @@ fields:
     show if:
       code: |
         financial_affairs.debtor_count > 1
+    required: False
     hide if:
       variable: financial_affairs.address_same_1
       is: True
@@ -99,6 +103,7 @@ fields:
     show if:
       code: |
         financial_affairs.debtor_count > 1
+    required: False
     hide if:
       variable: financial_affairs.address_same_1
       is: True
@@ -107,6 +112,7 @@ fields:
     show if:
       code: |
         financial_affairs.debtor_count > 1
+    required: False
   - From: financial_affairs.debtor2_address_from_1
     datatype: date
     show if:
@@ -128,6 +134,7 @@ fields:
   - Has second address: financial_affairs.has_second_address
     datatype: yesnoradio
     show if: financial_affairs.lived_elsewhere
+    required: False
   - note: Address 2
     show if: financial_affairs.has_second_address
   - Address/PO Box: financial_affairs.address_street_2
@@ -232,6 +239,7 @@ fields:
   - Do you have a third address?: financial_affairs.has_third_address
     datatype: yesnoradio
     show if: financial_affairs.has_second_address
+    required: False
   - note: Address 3
     show if: financial_affairs.has_third_address
   - Address/PO Box: financial_affairs.address_street_3
@@ -336,6 +344,7 @@ fields:
   - Do you have a fourth address?: financial_affairs.has_fourth_address
     datatype: yesnoradio
     show if: financial_affairs.has_third_address
+    required: False
   - note: Address 4
     show if: financial_affairs.has_fourth_address
   - Address/PO Box: financial_affairs.address_street_4
@@ -440,6 +449,7 @@ fields:
   - Do you have a fifth address?: financial_affairs.has_fifth_address
     datatype: yesnoradio
     show if: financial_affairs.has_fourth_address
+    required: False
   - note: Address 5
     show if: financial_affairs.has_fifth_address
   - Address/PO Box: financial_affairs.address_street_5
@@ -544,6 +554,7 @@ fields:
   - Do you have a sixth address?: financial_affairs.has_sixth_address
     datatype: yesnoradio
     show if: financial_affairs.has_fifth_address
+    required: False
   - note: Address 6
     show if: financial_affairs.has_sixth_address
   - Address/PO Box: financial_affairs.address_street_6
@@ -1099,6 +1110,7 @@ fields:
     show if:
       variable: financial_affairs.consumer_debt_payments[i].payment_for
       is: Other
+    required: False
 ---
 table: insider_payments_table
 rows: financial_affairs.insider_payments
@@ -1356,22 +1368,28 @@ fields:
     datatype: yesnoradio
   - Creditors Name: financial_affairs.refusal_creditor_name
     show if: financial_affairs.has_refusal
+    required: False
   - Address/PO Box: financial_affairs.refusal_creditor_street
     show if: financial_affairs.has_refusal
+    required: False
   - City: financial_affairs.refusal_creditor_city
     show if: financial_affairs.has_refusal
+    required: False
   - State: financial_affairs.refusal_creditor_state
     show if: financial_affairs.has_refusal
+    required: False
   - Zip: financial_affairs.refusal_creditor_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_refusal
+    required: False
   - note: Describe the action the creditor took
     show if: financial_affairs.has_refusal
   - no label: financial_affairs.refusal_description
     input type: area
     show if: financial_affairs.has_refusal
+    required: False
   - Last 4 digits of account number XXXX-: financial_affairs.refusal_account_number
     show if: financial_affairs.has_refusal
     required: False
@@ -1382,6 +1400,7 @@ fields:
   - Amount: financial_affairs.refusal_amount
     datatype: currency
     show if: financial_affairs.has_refusal
+    required: False
 ---
 question: |
   Property Assignee
@@ -1449,30 +1468,38 @@ fields:
     datatype: yesnoradio
   - Charity name: financial_affairs.charity_name
     show if: financial_affairs.has_charity
+    required: False
   - Address/PO Box: financial_affairs.charity_street
     show if: financial_affairs.has_charity
+    required: False
   - City: financial_affairs.charity_city
     show if: financial_affairs.has_charity
+    required: False
   - State: financial_affairs.charity_state
     show if: financial_affairs.has_charity
+    required: False
   - Zip: financial_affairs.charity_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_charity
+    required: False
   - note: Describe what you contributed
     show if: financial_affairs.has_charity
   - no label: financial_affairs.charity_description
     input type: area
     show if: financial_affairs.has_charity
+    required: False
   - note: Dates you contributed
     show if: financial_affairs.has_charity
   - no label: financial_affairs.charity_date_1
     input type: area
     show if: financial_affairs.has_charity
+    required: False
   - Value of the gift or contribution: financial_affairs.charity_value_1
     datatype: currency
     show if: financial_affairs.has_charity
+    required: False
 ---
 question: |
   Theft or Disaster Losses
@@ -1570,27 +1597,34 @@ fields:
     datatype: yesnoradio
   - Person who was paid: financial_affairs.creditor_help.name
     show if: financial_affairs.has_creditor_help
+    required: False
   - Address/PO Box: financial_affairs.creditor_help.street
     show if: financial_affairs.has_creditor_help
+    required: False
   - City: financial_affairs.creditor_help.city
     show if: financial_affairs.has_creditor_help
+    required: False
   - State: financial_affairs.creditor_help.state
     show if: financial_affairs.has_creditor_help
+    required: False
   - Zip: financial_affairs.creditor_help.zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_creditor_help
+    required: False
   - note: Description and value of any property transferred
     show if: financial_affairs.has_creditor_help
   - no label: financial_affairs.creditor_help.property_description
     input type: area
     show if: financial_affairs.has_creditor_help
+    required: False
   - note: Date payment or transfer was made
     show if: financial_affairs.has_creditor_help
   - no label: financial_affairs.creditor_help.date_1
     datatype: date
     show if: financial_affairs.has_creditor_help
+    required: False
   - no label: financial_affairs.creditor_help.date_2
     datatype: date
     required: False
@@ -1600,6 +1634,7 @@ fields:
   - no label: financial_affairs.creditor_help.value_1
     datatype: currency
     show if: financial_affairs.has_creditor_help
+    required: False
   - no label: financial_affairs.creditor_help.value_2
     datatype: currency
     required: False
@@ -1661,14 +1696,17 @@ fields:
   - Name of trust: financial_affairs.self_settled_trust.name
     input type: area
     show if: financial_affairs.has_self_settled_trust
+    required: False
   - note: Description and value of the property transferred
     show if: financial_affairs.has_self_settled_trust
   - no label: financial_affairs.self_settled_trust.description
     input type: area
     show if: financial_affairs.has_self_settled_trust
+    required: False
   - Date transfer was made: financial_affairs.self_settled_trust.date
     datatype: date
     show if: financial_affairs.has_self_settled_trust
+    required: False
 ---
 table: instruments_table
 rows: financial_affairs.instruments
@@ -1722,6 +1760,7 @@ fields:
     show if:
       variable: financial_affairs.instruments[i].account_type
       is: Other
+    required: False
   - note: Date account was closed, sold, moved, or transferred
   - no label: financial_affairs.instruments[i].date
     input type: area
@@ -1738,17 +1777,22 @@ fields:
     datatype: yesnoradio
   - Name of financial institution: financial_affairs.deposit_box.name
     show if: financial_affairs.has_deposit_box
+    required: False
   - Address/PO Box: financial_affairs.deposit_box.street
     show if: financial_affairs.has_deposit_box
+    required: False
   - City: financial_affairs.deposit_box.city
     show if: financial_affairs.has_deposit_box
+    required: False
   - State: financial_affairs.deposit_box.state
     show if: financial_affairs.has_deposit_box
+    required: False
   - Zip: financial_affairs.deposit_box.zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_deposit_box
+    required: False
   - note: Who else had access to it?
     show if: financial_affairs.has_deposit_box
   - Name: financial_affairs.deposit_box.other_name
@@ -1774,9 +1818,11 @@ fields:
   - no label: financial_affairs.deposit_box.contents
     input type: area
     show if: financial_affairs.has_deposit_box
+    required: False
   - Do you still have it?: financial_affairs.deposit_box.still_owns
     datatype: yesnoradio
     show if: financial_affairs.has_deposit_box
+    required: False
 ---
 question: |
   Storage Unit
@@ -1787,17 +1833,22 @@ fields:
     datatype: yesnoradio
   - Name of storage facility: financial_affairs.storage_unit.name
     show if: financial_affairs.has_storage_unit
+    required: False
   - Address/PO Box: financial_affairs.storage_unit.street
     show if: financial_affairs.has_storage_unit
+    required: False
   - City: financial_affairs.storage_unit.city
     show if: financial_affairs.has_storage_unit
+    required: False
   - State: financial_affairs.storage_unit.state
     show if: financial_affairs.has_storage_unit
+    required: False
   - Zip: financial_affairs.storage_unit.zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_storage_unit
+    required: False
   - note: Who else had access to it?
     show if: financial_affairs.has_storage_unit
   - Name: financial_affairs.storage_unit.other_name
@@ -1823,9 +1874,11 @@ fields:
   - no label: financial_affairs.storage_unit.contents
     input type: area
     show if: financial_affairs.has_storage_unit
+    required: False
   - Do you still have it?: financial_affairs.storage_unit.still_owns
     datatype: yesnoradio
     show if: financial_affairs.has_storage_unit
+    required: False
 ---
 question: |
   Borrowed Property
@@ -1836,38 +1889,49 @@ fields:
     datatype: yesnoradio
   - Owner's name: financial_affairs.held_property.name
     show if: financial_affairs.has_held_property
+    required: False
   - Address/PO Box: financial_affairs.held_property.street
     show if: financial_affairs.has_held_property
+    required: False
   - City: financial_affairs.held_property.city
     show if: financial_affairs.has_held_property
+    required: False
   - State: financial_affairs.held_property.state
     show if: financial_affairs.has_held_property
+    required: False
   - Zip: financial_affairs.held_property.zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_held_property
+    required: False
   - note: Where is the property?
     show if: financial_affairs.has_held_property
   - Address/PO Box: financial_affairs.held_property.prop_street
     show if: financial_affairs.has_held_property
+    required: False
   - City: financial_affairs.held_property.prop_city
     show if: financial_affairs.has_held_property
+    required: False
   - State: financial_affairs.held_property.prop_state
     show if: financial_affairs.has_held_property
+    required: False
   - Zip: financial_affairs.held_property.prop_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_held_property
+    required: False
   - note: Describe the property
     show if: financial_affairs.has_held_property
   - no label: financial_affairs.held_property.property_description
     input type: area
     show if: financial_affairs.has_held_property
+    required: False
   - Value: financial_affairs.held_property.value
     datatype: currency
     show if: financial_affairs.has_held_property
+    required: False
 ---
 id: environmental_hazardous_gateway
 question: |
@@ -1896,42 +1960,54 @@ fields:
     datatype: yesnoradio
   - Name of site: financial_affairs.environment.liability_name
     show if: financial_affairs.environment.has_liability
+    required: False
   - Address/PO Box: financial_affairs.environment.liability_street
     show if: financial_affairs.environment.has_liability
+    required: False
   - City: financial_affairs.environment.liability_city
     show if: financial_affairs.environment.has_liability
+    required: False
   - State: financial_affairs.environment.liability_state
     show if: financial_affairs.environment.has_liability
+    required: False
   - Zip: financial_affairs.environment.liability_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.environment.has_liability
+    required: False
   - note: Government Unit
     show if: financial_affairs.environment.has_liability
   - Name: financial_affairs.environment.liability_unit_name
     show if: financial_affairs.environment.has_liability
+    required: False
   - Address/PO Box: financial_affairs.environment.liability_unit_street
     show if: financial_affairs.environment.has_liability
+    required: False
   - City: financial_affairs.environment.liability_unit_city
     show if: financial_affairs.environment.has_liability
+    required: False
   - State: financial_affairs.environment.liability_unit_state
     show if: financial_affairs.environment.has_liability
+    required: False
   - Zip: financial_affairs.environment.liability_unit_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.environment.has_liability
+    required: False
   - note: Environmental law, if you know it
     show if: financial_affairs.environment.has_liability
   - no label: financial_affairs.environment.liability_law
     input type: area
     show if: financial_affairs.environment.has_liability
+    required: False
   - note: Date of notice
     show if: financial_affairs.environment.has_liability
   - no label: financial_affairs.environment.liability_date
     datatype: date
     show if: financial_affairs.environment.has_liability
+    required: False
 ---
 id: hazardous_material_release
 question: |
@@ -1943,42 +2019,54 @@ fields:
     datatype: yesnoradio
   - Name of site: financial_affairs.environment.release_name
     show if: financial_affairs.environment.has_release
+    required: False
   - Address/PO Box: financial_affairs.environment.release_street
     show if: financial_affairs.environment.has_release
+    required: False
   - City: financial_affairs.environment.release_city
     show if: financial_affairs.environment.has_release
+    required: False
   - State: financial_affairs.environment.release_state
     show if: financial_affairs.environment.has_release
+    required: False
   - Zip: financial_affairs.environment.release_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.environment.has_release
+    required: False
   - note: Government Unit
     show if: financial_affairs.environment.has_release
   - Name: financial_affairs.environment.release_unit_name
     show if: financial_affairs.environment.has_release
+    required: False
   - Address/PO Box: financial_affairs.environment.release_unit_street
     show if: financial_affairs.environment.has_release
+    required: False
   - City: financial_affairs.environment.release_unit_city
     show if: financial_affairs.environment.has_release
+    required: False
   - State: financial_affairs.environment.release_unit_state
     show if: financial_affairs.environment.has_release
+    required: False
   - Zip: financial_affairs.environment.release_unit_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.environment.has_release
+    required: False
   - note: Environmental law, if you know it
     show if: financial_affairs.environment.has_release
   - no label: financial_affairs.environment.release_law
     input type: area
     show if: financial_affairs.environment.has_release
+    required: False
   - note: Date of notice
     show if: financial_affairs.environment.has_release
   - no label: financial_affairs.environment.release_date
     datatype: date
     show if: financial_affairs.environment.has_release
+    required: False
 ---
 id: environmental_judicial_proceeding
 question: |
@@ -1991,35 +2079,44 @@ fields:
   - Case title: financial_affairs.environment.proceeding_case_title
     input type: area
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - Case number: financial_affairs.environment.proceeding_case_number
     datatype: string
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - note: Court or agency
     show if: financial_affairs.environment.has_proceeding
   - Court Name: financial_affairs.environment.proceeding_court_name
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - Address/PO Box: financial_affairs.environment.proceeding_court_street
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - City: financial_affairs.environment.proceeding_court_city
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - State: financial_affairs.environment.proceeding_court_state
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - Zip: financial_affairs.environment.proceeding_court_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - note: Nature of the case
     show if: financial_affairs.environment.has_proceeding
   - no label: financial_affairs.environment.proceeding_description
     input type: area
     show if: financial_affairs.environment.has_proceeding
+    required: False
   - Status of the case: financial_affairs.environment.proceeding_status
     choices:
       - Pending
       - On appeal
       - Concluded
     show if: financial_affairs.environment.has_proceeding
+    required: False
 ---
 id: business_connections
 question: |
@@ -2097,17 +2194,22 @@ fields:
     datatype: yesnoradio
   - Name: financial_affairs.statement_name
     show if: financial_affairs.has_statement
+    required: False
   - Address/PO Box: financial_affairs.statement_street
     show if: financial_affairs.has_statement
+    required: False
   - City: financial_affairs.statement_city
     show if: financial_affairs.has_statement
+    required: False
   - State: financial_affairs.statement_state
     show if: financial_affairs.has_statement
+    required: False
   - Zip: financial_affairs.statement_zip
     datatype: text
     minlength: 5
     maxlength: 5
     show if: financial_affairs.has_statement
+    required: False
   - note: Date issued
     show if: financial_affairs.has_statement
   - no label: financial_affairs.statement_date

--- a/docassemble/BankruptcyClinic/data/questions/2030-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/2030-question-blocks.yml
@@ -77,7 +77,7 @@ fields:
     show if:
       variable: attorney_disclosure.source_paid
       is: other
-    required: True
+    required: False
 section: attorney_disc
 ---
 id: compensation_source_future
@@ -95,7 +95,7 @@ fields:
     show if:
       variable: attorney_disclosure.source_topay
       is: other
-    required: True
+    required: False
 section: attorney_disc
 ---
 id: fee_sharing

--- a/tests/probe-cash-on-hand.spec.ts
+++ b/tests/probe-cash-on-hand.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Probe: does the cash_on_hand page advance under strict Continue when the
+ * user picks "No" on the only required field (`prop.financial_assets.has_cash`)?
+ *
+ * If this passes, the walker's silent-block report was a walker-side false
+ * positive (radio-setting bug) rather than a real silent block.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { b64, waitForDaPageLoad } from './helpers';
+import {
+  navigateToDebtorPage, fillDebtorAndAdvance, passDebtorFinal,
+} from './navigation-helpers';
+
+async function getHeading(p: import('@playwright/test').Page) {
+  return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
+}
+
+async function advanceUntilHeading(p: import('@playwright/test').Page, target: RegExp, maxSteps = 50) {
+  for (let i = 0; i < maxSteps; i++) {
+    const h = await getHeading(p);
+    if (target.test(h)) return h;
+    // Click No on any yesno-button page; otherwise click Continue (masked)
+    const noBtn = p.locator(`button:has-text("No"):visible`).first();
+    if (await noBtn.count() > 0) {
+      // Make sure it's a docassemble yesno button (not the in-page Back)
+      const isContinue = (await p.locator('#da-continue-button').count()) > 0;
+      if (!isContinue) {
+        await noBtn.click().catch(() => {});
+        await p.waitForLoadState('networkidle').catch(() => {});
+        continue;
+      }
+    }
+    // Fall through: masked click
+    const { clickContinue } = await import('./helpers');
+    // Pick "No" on any radio groups
+    await p.evaluate(() => {
+      document.querySelectorAll('input[type="radio"]').forEach((r) => {
+        const radio = r as HTMLInputElement;
+        const name = radio.name;
+        if (!name) return;
+        const group = document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`);
+        const anyChecked = Array.from(group).some(g => (g as HTMLInputElement).checked);
+        if (anyChecked) return;
+        const noOne = Array.from(group).find(g => {
+          const v = (g as HTMLInputElement).value;
+          return v === 'False' || v === 'No' || v === 'false';
+        });
+        const target = (noOne || group[0]) as HTMLInputElement;
+        const lab = target?.id ? document.querySelector(`label[for="${target.id}"]`) as HTMLElement : null;
+        if (lab) lab.click();
+        else { target.checked = true; target.dispatchEvent(new Event('change', { bubbles: true })); }
+      });
+    });
+    await clickContinue(p);
+    await waitForDaPageLoad(p);
+  }
+  return await getHeading(p);
+}
+
+test.setTimeout(420_000);
+
+test('cash_on_hand advances under strict Continue with label-click on radio', async ({ page }) => {
+  await navigateToDebtorPage(page, SIMPLE_SINGLE);
+  await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+  await passDebtorFinal(page);
+
+  // Drive forward until "What is your cash on hand?" appears.
+  const heading = await advanceUntilHeading(page, /cash on hand/i, 50);
+  console.log(`[probe] arrived at: "${heading}"`);
+  expect(heading.toLowerCase()).toContain('cash on hand');
+
+  // Click label for No on the only required field (has_cash).
+  const hasCashId = b64('prop.financial_assets.has_cash');
+  // Bootstrap-styled radios: the "No" is _1.
+  await page.locator(`label[for="${hasCashId}_1"]`).click();
+  await page.waitForTimeout(400);
+
+  // STRICT Continue — no validator hack.
+  await page.locator('#da-continue-button').click();
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(800);
+
+  const after = await getHeading(page);
+  console.log(`[probe] after strict Continue: "${after}"`);
+  expect(after.toLowerCase()).not.toContain('cash on hand');
+});

--- a/tests/probe-means-test-consumer.spec.ts
+++ b/tests/probe-means-test-consumer.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Probe: does the means_test_exemptions page advance under both masked AND
+ * strict Continue when the user answers No / No / No (the consumer-debts
+ * path that drives the if-branch into household_and_dependents_info)?
+ *
+ * Earlier observations (before the bulk fix) showed this page silently
+ * failing on the all-False case while T/F/F advanced cleanly. With the bulk
+ * fix in place — including required:False on the separated_status field of
+ * the downstream household_and_dependents_info page — both paths should now
+ * succeed.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { waitForDaPageLoad } from './helpers';
+import {
+  navigateToDebtorPage, fillDebtorAndAdvance, passDebtorFinal,
+  navigatePropertySection, navigateExemptionSection,
+  navigateCreditorLibraryPicker, navigateSecuredCreditors,
+  navigateUnsecuredCreditors, navigateContractsLeases,
+  navigateCommunityProperty, navigateIncome, navigateExpenses,
+  navigateFinancialAffairs, navigateReporting, navigatePersonalLeases,
+} from './navigation-helpers';
+
+async function getHeading(p: import('@playwright/test').Page) {
+  return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
+}
+
+async function reachMeansTestExemptions(page: import('@playwright/test').Page) {
+  await navigateToDebtorPage(page, SIMPLE_SINGLE);
+  await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+  await passDebtorFinal(page);
+  await navigatePropertySection(page, SIMPLE_SINGLE);
+  await navigateExemptionSection(page);
+  await navigateCreditorLibraryPicker(page);
+  await navigateSecuredCreditors(page, SIMPLE_SINGLE);
+  await navigateUnsecuredCreditors(page, SIMPLE_SINGLE);
+  await navigateContractsLeases(page);
+  await navigateCommunityProperty(page);
+  await navigateIncome(page, SIMPLE_SINGLE);
+  await navigateExpenses(page, SIMPLE_SINGLE.rentExpense, 0);
+  await navigateFinancialAffairs(page, SIMPLE_SINGLE);
+  await navigateReporting(page);
+  await navigatePersonalLeases(page);
+
+  // means_test_presumption_of_abuse (single select field)
+  await waitForDaPageLoad(page);
+  const { selectByName, b64, clickContinue } = await import('./helpers');
+  await selectByName(page, b64('monthly_income.means_type'), 'There is no presumption of abuse.');
+  await clickContinue(page);
+  await waitForDaPageLoad(page);
+  // Now on means_test_exemptions
+}
+
+test.setTimeout(420_000);
+
+test('means_test_exemptions advances under masked Continue with all-No (consumer debts)', async ({ page }) => {
+  await reachMeansTestExemptions(page);
+
+  const heading = await getHeading(page);
+  expect(heading.toLowerCase()).toContain('identify any exemptions from presumption of abuse');
+
+  // Click No on each of the 3 yesnoradios via label
+  await page.evaluate(() => {
+    const names = ['monthly_income.non_consumer_debts', 'monthly_income.disabled_veteran', 'monthly_income.reservists'];
+    names.forEach((name) => {
+      // docassemble b64: standard base64, no padding
+      const b64 = btoa(name).replace(/=+$/, '');
+      const labelNo = document.querySelector(`label[for="${b64}_1"]`) as HTMLElement | null;
+      if (labelNo && labelNo.offsetParent !== null) labelNo.click();
+    });
+  });
+  await page.waitForTimeout(600);
+
+  const { clickContinue } = await import('./helpers');
+  await clickContinue(page);
+  await page.waitForTimeout(1500);
+
+  const after = await getHeading(page);
+  console.log(`[probe-masked-all-No] after Continue: "${after}"`);
+  expect(after.toLowerCase()).not.toContain('identify any exemptions');
+  expect(after.toLowerCase()).toContain('tell the court about your household and dependents');
+});
+
+test('means_test_exemptions advances under STRICT Continue with all-No (consumer debts)', async ({ page }) => {
+  await reachMeansTestExemptions(page);
+
+  const heading = await getHeading(page);
+  expect(heading.toLowerCase()).toContain('identify any exemptions from presumption of abuse');
+
+  await page.evaluate(() => {
+    const names = ['monthly_income.non_consumer_debts', 'monthly_income.disabled_veteran', 'monthly_income.reservists'];
+    names.forEach((name) => {
+      // docassemble b64: standard base64, no padding
+      const b64 = btoa(name).replace(/=+$/, '');
+      const labelNo = document.querySelector(`label[for="${b64}_1"]`) as HTMLElement | null;
+      if (labelNo && labelNo.offsetParent !== null) labelNo.click();
+    });
+  });
+  await page.waitForTimeout(600);
+
+  // STRICT — no validator override
+  await page.locator('#da-continue-button').click();
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1500);
+
+  const after = await getHeading(page);
+  console.log(`[probe-strict-all-No] after strict Continue: "${after}"`);
+  expect(after.toLowerCase()).not.toContain('identify any exemptions');
+});

--- a/tests/probe-nonpriority-claim.spec.ts
+++ b/tests/probe-nonpriority-claim.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Probe: does the nonpriority_unsecured_claim_details page advance under
+ * strict Continue when every visible required field is filled with a safe
+ * default (radios → first option, currency → 0, text → "N/A", etc.)?
+ *
+ * Walker v4 reported this page as a silent block. If this probe PASSES, the
+ * walker has another visibility/selector bug. If it FAILS, there is a real
+ * silent-block condition on this page that needs a separate fix.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { waitForDaPageLoad } from './helpers';
+import {
+  navigateToDebtorPage, fillDebtorAndAdvance, passDebtorFinal,
+} from './navigation-helpers';
+
+async function getHeading(p: import('@playwright/test').Page) {
+  return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
+}
+
+test.setTimeout(420_000);
+
+test('nonpriority_unsecured_claim_details — strict Continue with safe-default fill', async ({ page }) => {
+  await navigateToDebtorPage(page, SIMPLE_SINGLE);
+  await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+  await passDebtorFinal(page);
+
+  const { clickContinue } = await import('./helpers');
+
+  // Advance to the nonpriority page using masked clicks + safe-defaults.
+  for (let i = 0; i < 60; i++) {
+    const h = await getHeading(page);
+    if (/tell the court about a nonpriority unsecured claim/i.test(h)) break;
+    // No-button page?
+    const hasContinue = (await page.locator('#da-continue-button').count()) > 0;
+    if (!hasContinue) {
+      await page.locator('button:has-text("No"):visible').first().click().catch(() => {});
+      await page.waitForLoadState('networkidle').catch(() => {});
+      continue;
+    }
+    await page.evaluate(() => {
+      // Same label-click radio logic as walker
+      const seen = new Set<string>();
+      document.querySelectorAll('input[type="radio"]').forEach((r) => {
+        const radio = r as HTMLInputElement;
+        const name = radio.name;
+        if (!name || seen.has(name)) return;
+        seen.add(name);
+        const group = Array.from(
+          document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`)
+        ) as HTMLInputElement[];
+        if (group.some((g) => g.checked)) return;
+        const visibleByLabel = group.filter((g) => {
+          if (!g.id) return false;
+          const lab = document.querySelector(`label[for="${CSS.escape(g.id)}"]`) as HTMLElement | null;
+          return !!lab && lab.offsetParent !== null;
+        });
+        if (visibleByLabel.length === 0) return;
+        const noOne = visibleByLabel.find((g) => {
+          const v = g.value;
+          return v === 'False' || v === 'No' || v === 'false' || v === '0';
+        });
+        const t = noOne || visibleByLabel[0];
+        const lab = document.querySelector(`label[for="${CSS.escape(t.id)}"]`) as HTMLElement;
+        lab.click();
+      });
+      // selects
+      document.querySelectorAll('select').forEach((sel) => {
+        const s = sel as HTMLSelectElement;
+        if (s.offsetParent === null || (s.value && s.value !== '')) return;
+        for (const opt of Array.from(s.options)) {
+          if (opt.value && opt.value !== '') { s.value = opt.value; s.dispatchEvent(new Event('change', { bubbles: true })); break; }
+        }
+      });
+      // text/number/currency inputs
+      document.querySelectorAll('input').forEach((el) => {
+        const i = el as HTMLInputElement;
+        if (i.offsetParent === null || i.value) return;
+        const t = (i.type || '').toLowerCase();
+        if (['hidden','submit','button','reset','file','radio','checkbox'].includes(t)) return;
+        const label = i.id ? document.querySelector(`label[for="${i.id}"]`) : null;
+        const labelText = (label?.textContent || '').toLowerCase();
+        let v = 'N/A';
+        if (t === 'number' || t === 'tel') v = '0';
+        else if (labelText.includes('zip')) v = '68508';
+        else if (labelText.includes('amount') || labelText.includes('income') || labelText.includes('value') || labelText.includes('pay') || labelText.includes('expense') || labelText.includes('count') || labelText.includes('claim')) v = '0';
+        else if (t === 'date') v = '2024-01-01';
+        else if (labelText.includes('year')) v = '2020';
+        else if (labelText.includes('name')) v = 'Test Person';
+        else if (labelText.includes('street') || labelText.includes('address')) v = '123 Test St';
+        else if (labelText.includes('city')) v = 'Lincoln';
+        i.value = v;
+        i.dispatchEvent(new Event('input', { bubbles: true }));
+        i.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    });
+    await clickContinue(page);
+    await waitForDaPageLoad(page);
+  }
+
+  const heading = await getHeading(page);
+  console.log(`[probe] reached: "${heading}"`);
+  expect(heading.toLowerCase()).toContain('nonpriority unsecured claim');
+  await page.waitForTimeout(800);
+
+  // Now: fill every visible required field, then STRICT click.
+  await page.evaluate(() => {
+    // Same fill logic — used to make sure every required is set.
+    const seen = new Set<string>();
+    document.querySelectorAll('input[type="radio"]').forEach((r) => {
+      const radio = r as HTMLInputElement;
+      const name = radio.name;
+      if (!name || seen.has(name)) return;
+      seen.add(name);
+      const group = Array.from(
+        document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`)
+      ) as HTMLInputElement[];
+      if (group.some((g) => g.checked)) return;
+      const visibleByLabel = group.filter((g) => {
+        if (!g.id) return false;
+        const lab = document.querySelector(`label[for="${CSS.escape(g.id)}"]`) as HTMLElement | null;
+        return !!lab && lab.offsetParent !== null;
+      });
+      if (visibleByLabel.length === 0) return;
+      const noOne = visibleByLabel.find((g) => {
+        const v = g.value;
+        return v === 'False' || v === 'No' || v === 'false';
+      });
+      const t = noOne || visibleByLabel[0];
+      const lab = document.querySelector(`label[for="${CSS.escape(t.id)}"]`) as HTMLElement;
+      lab.click();
+    });
+    document.querySelectorAll('select').forEach((sel) => {
+      const s = sel as HTMLSelectElement;
+      if (s.offsetParent === null || (s.value && s.value !== '')) return;
+      for (const opt of Array.from(s.options)) {
+        if (opt.value && opt.value !== '') { s.value = opt.value; s.dispatchEvent(new Event('change', { bubbles: true })); break; }
+      }
+    });
+    document.querySelectorAll('input').forEach((el) => {
+      const i = el as HTMLInputElement;
+      if (i.offsetParent === null || i.value) return;
+      const t = (i.type || '').toLowerCase();
+      if (['hidden','submit','button','reset','file','radio','checkbox'].includes(t)) return;
+      const label = i.id ? document.querySelector(`label[for="${i.id}"]`) : null;
+      const labelText = (label?.textContent || '').toLowerCase();
+      let v = 'N/A';
+      if (labelText.includes('zip')) v = '68508';
+      else if (labelText.includes('amount') || labelText.includes('claim') || labelText.includes('value')) v = '0';
+      else if (t === 'date') v = '2024-01-01';
+      else if (labelText.includes("creditor's name") || labelText.includes("name")) v = 'Test Creditor';
+      else if (labelText.includes('street') || labelText.includes('address')) v = '123 Test St';
+      else if (labelText.includes('city')) v = 'Lincoln';
+      i.value = v;
+      i.dispatchEvent(new Event('input', { bubbles: true }));
+      i.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+  await page.waitForTimeout(800);
+
+  await page.screenshot({ path: 'test-results/probe-nonpriority-pre.png', fullPage: true });
+
+  // STRICT click
+  await page.locator('#da-continue-button').click();
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1500);
+
+  const after = await getHeading(page);
+  await page.screenshot({ path: 'test-results/probe-nonpriority-post.png', fullPage: true });
+  console.log(`[probe] after strict Continue: "${after}"`);
+  expect(after.toLowerCase()).not.toContain('nonpriority unsecured claim');
+});

--- a/tests/probe-personal-household.spec.ts
+++ b/tests/probe-personal-household.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Probe: does the personal_household_items page (Schedule A/B's massive
+ * multi-yesnoradio screen) advance under strict Continue when the user picks
+ * No on every top-level yesnoradio (the realistic minimum-effort case)?
+ *
+ * This is the page the walker most loudly flagged as a silent block. We
+ * believe that was a walker-side false positive caused by setting
+ * `.checked = true` without a label click. Real users click labels.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { waitForDaPageLoad } from './helpers';
+import {
+  navigateToDebtorPage, fillDebtorAndAdvance, passDebtorFinal,
+} from './navigation-helpers';
+
+async function getHeading(p: import('@playwright/test').Page) {
+  return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
+}
+
+async function advanceUntilHeading(p: import('@playwright/test').Page, target: RegExp, maxSteps = 30) {
+  for (let i = 0; i < maxSteps; i++) {
+    const h = await getHeading(p);
+    if (target.test(h)) return h;
+    const noBtn = p.locator(`button:has-text("No"):visible`).first();
+    const hasContinue = (await p.locator('#da-continue-button').count()) > 0;
+    if (await noBtn.count() > 0 && !hasContinue) {
+      await noBtn.click().catch(() => {});
+      await p.waitForLoadState('networkidle').catch(() => {});
+      continue;
+    }
+    const { clickContinue } = await import('./helpers');
+    await p.evaluate(() => {
+      document.querySelectorAll('input[type="radio"]').forEach((r) => {
+        const radio = r as HTMLInputElement;
+        const name = radio.name;
+        if (!name) return;
+        const group = document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`);
+        if (Array.from(group).some(g => (g as HTMLInputElement).checked)) return;
+        const noOne = Array.from(group).find(g => {
+          const v = (g as HTMLInputElement).value;
+          return v === 'False' || v === 'No' || v === 'false';
+        });
+        const t = (noOne || group[0]) as HTMLInputElement;
+        const lab = t?.id ? document.querySelector(`label[for="${t.id}"]`) as HTMLElement : null;
+        if (lab) lab.click();
+        else { t.checked = true; t.dispatchEvent(new Event('change', { bubbles: true })); }
+      });
+    });
+    await clickContinue(p);
+    await waitForDaPageLoad(p);
+  }
+  return await getHeading(p);
+}
+
+test.setTimeout(420_000);
+
+test('personal_household_items advances under strict Continue with all-No', async ({ page }) => {
+  await navigateToDebtorPage(page, SIMPLE_SINGLE);
+  await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+  await passDebtorFinal(page);
+
+  const heading = await advanceUntilHeading(page, /describe your personal and household items/i, 30);
+  console.log(`[probe] arrived at: "${heading}"`);
+  expect(heading.toLowerCase()).toContain('personal and household items');
+
+  // Click every top-level yesnoradio "No" via label click. CRITICAL: check
+  // the LABEL's visibility, not the input — docassemble's Bootstrap
+  // `btn-check` pattern intentionally hides the input (`offsetParent === null`)
+  // and uses the label as the visible/clickable element.
+  await page.evaluate(() => {
+    const seen = new Set<string>();
+    document.querySelectorAll('input[type="radio"]').forEach((r) => {
+      const radio = r as HTMLInputElement;
+      const name = radio.name;
+      if (!name || seen.has(name)) return;
+      seen.add(name);
+      const group = Array.from(
+        document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`)
+      ) as HTMLInputElement[];
+      if (group.some(g => g.checked)) return;
+      // Filter to inputs whose LABEL is visible (Bootstrap btn-check pattern)
+      const visibleByLabel = group.filter(g => {
+        if (!g.id) return false;
+        const lab = document.querySelector(`label[for="${CSS.escape(g.id)}"]`) as HTMLElement | null;
+        return !!lab && lab.offsetParent !== null;
+      });
+      if (visibleByLabel.length === 0) return;
+      const noOne = visibleByLabel.find(g => {
+        const v = g.value;
+        return v === 'False' || v === 'No' || v === 'false';
+      });
+      const target = noOne || visibleByLabel[0];
+      const lab = document.querySelector(`label[for="${CSS.escape(target.id)}"]`) as HTMLElement;
+      lab.click();
+    });
+  });
+  await page.waitForTimeout(800);
+
+  // STRICT Continue.
+  await page.locator('#da-continue-button').click();
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1000);
+
+  const after = await getHeading(page);
+  console.log(`[probe] after strict Continue: "${after}"`);
+  expect(after.toLowerCase()).not.toContain('personal and household items');
+});

--- a/tests/strict-validator-walker.spec.ts
+++ b/tests/strict-validator-walker.spec.ts
@@ -198,18 +198,27 @@ test.describe('Strict-validator interview walker', () => {
         break;
       }
 
-      // Normal page with Continue button: fill required fields, click STRICT
+      // Normal page with Continue button: fill required fields, click STRICT.
+      // Read the page's `_tracker` hidden field BEFORE submitting; if the
+      // tracker advances, the server accepted the form even if the heading
+      // is the same (e.g. generic-index gather pages repeat the heading).
+      const trackerBefore = await page.locator('input[name="_tracker"]').first().getAttribute('value').catch(() => null);
       const handled = await fillVisibleRequiredFields(page);
-      if (handled) await page.waitForTimeout(250);
+      if (handled) await page.waitForTimeout(400);
 
       await clickContinueStrict(page);
-      await page.waitForTimeout(300);
+      await page.waitForTimeout(800);
 
       const h2 = (await getHeading(page)).toLowerCase();
-      if (h2 === hLow) {
+      const trackerAfter = await page.locator('input[name="_tracker"]').first().getAttribute('value').catch(() => null);
+      const headingSame = (h2 === hLow);
+      const trackerAdvanced = (trackerBefore !== null && trackerAfter !== null && trackerBefore !== trackerAfter);
+      if (headingSame && !trackerAdvanced) {
         sameHeadingStreak += 1;
         if (sameHeadingStreak === 1) {
-          // Try once more — sometimes the click was eaten by show-if JS
+          // Try once more with a longer settle — show-if JS or server-side
+          // rendering can take a beat. Don't immediately report a block.
+          await page.waitForTimeout(800);
           continue;
         }
         // Silent block confirmed. Record + escape with masked Continue.
@@ -221,6 +230,8 @@ test.describe('Strict-validator interview walker', () => {
         await page.waitForLoadState('networkidle').catch(() => {});
         sameHeadingStreak = 0;
       } else {
+        // Heading changed OR tracker advanced (gather loop, same heading
+        // for next item). Either way, real progress was made.
         sameHeadingStreak = 0;
       }
       lastHeading = h;

--- a/tests/strict-validator-walker.spec.ts
+++ b/tests/strict-validator-walker.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Strict-validator interview walker.
+ *
+ * Walks the interview start-to-finish using the REAL-user click pattern —
+ * a plain Continue click that does NOT override the jQuery validator's
+ * `ignore` setting. Any page where Continue silently fails to advance
+ * (after the walker has filled every visible required field) is reported
+ * as a candidate silent-block bug of the same class as Lea's #98 fix.
+ *
+ * Logic per iteration:
+ *   1. Read the current page heading.
+ *   2. Find and answer all visible required fields with safe defaults
+ *      (No on yes/no, 0 on currency/number, first option on dropdowns,
+ *      "N/A" on text inputs).
+ *   3. Click `#da-continue-button` STRICTLY (no validator hack).
+ *   4. Wait briefly; check heading.
+ *      - If heading changed ⇒ advance.
+ *      - If heading unchanged after 2 attempts ⇒ record as silent block,
+ *        ESCAPE using the masked `clickContinue` (the hack-y one), and
+ *        continue so we surface every blocker in one run.
+ *
+ * Stop at the conclusion / Form-101-output page, or after maxSteps.
+ *
+ * Output: prints a list of every silently-blocked page heading; the test
+ * passes if the list is empty.
+ */
+import { test, expect, Page } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  b64, waitForDaPageLoad, clickContinue,
+} from './helpers';
+import { navigateToDebtorPage, fillDebtorAndAdvance } from './navigation-helpers';
+
+async function getHeading(p: Page) {
+  return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
+}
+
+async function fillVisibleRequiredFields(p: Page): Promise<boolean> {
+  // Fill every visible empty required form input with a safe default. Returns
+  // true if at least one field was touched.
+  return await p.evaluate(() => {
+    let touched = false;
+
+    // 1) selects (dropdowns) — pick first non-empty option
+    document.querySelectorAll('select').forEach((sel) => {
+      const s = sel as HTMLSelectElement;
+      if (s.offsetParent === null) return;
+      if (s.value && s.value !== '') return;
+      for (const opt of Array.from(s.options)) {
+        if (opt.value && opt.value !== '') {
+          s.value = opt.value;
+          s.dispatchEvent(new Event('change', { bubbles: true }));
+          touched = true;
+          break;
+        }
+      }
+    });
+
+    // 2) yesno-radio groups — pick "No" if unselected
+    document.querySelectorAll('input[type="radio"]').forEach((r) => {
+      const radio = r as HTMLInputElement;
+      if (radio.offsetParent === null) return;
+      const name = radio.name;
+      if (!name) return;
+      const group = document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`);
+      const anyChecked = Array.from(group).some((g) => (g as HTMLInputElement).checked);
+      if (anyChecked) return;
+      const noOne = Array.from(group).find((g) => {
+        const v = (g as HTMLInputElement).value;
+        return v === 'False' || v === 'No' || v === 'false';
+      });
+      const target = (noOne || group[0]) as HTMLInputElement;
+      if (target) {
+        target.checked = true;
+        target.dispatchEvent(new Event('change', { bubbles: true }));
+        touched = true;
+      }
+    });
+
+    // 3) text/number/currency/date inputs — fill safe defaults
+    document.querySelectorAll('input').forEach((el) => {
+      const i = el as HTMLInputElement;
+      if (i.offsetParent === null) return;
+      if (i.value) return;
+      const t = (i.type || '').toLowerCase();
+      if (['hidden', 'submit', 'button', 'reset', 'file', 'radio', 'checkbox'].includes(t)) return;
+      const label = i.id ? document.querySelector(`label[for="${i.id}"]`) : null;
+      const labelText = (label?.textContent || '').toLowerCase();
+      let v = 'N/A';
+      if (t === 'number' || t === 'tel') v = '0';
+      else if (labelText.includes('zip')) v = '68508';
+      else if (
+        labelText.includes('amount') || labelText.includes('income') ||
+        labelText.includes('value') || labelText.includes('pay') ||
+        labelText.includes('expense') || labelText.includes('count') ||
+        labelText.includes('mileage') || labelText.includes('milage')
+      ) v = '0';
+      else if (t === 'date') v = '2024-01-01';
+      else if (t === 'email') v = 'test@example.com';
+      else if (labelText.includes('year')) v = '2020';
+      else if (labelText.includes('name')) v = 'Test Person';
+      else if (labelText.includes('street') || labelText.includes('address')) v = '123 Test St';
+      else if (labelText.includes('city')) v = 'Lincoln';
+      i.value = v;
+      i.dispatchEvent(new Event('input', { bubbles: true }));
+      i.dispatchEvent(new Event('change', { bubbles: true }));
+      touched = true;
+    });
+
+    return touched;
+  }).catch(() => false);
+}
+
+async function clickContinueStrict(p: Page) {
+  await waitForDaPageLoad(p);
+  // Plain click — no validator override. Real-user click path.
+  await p.locator('#da-continue-button').click({ timeout: 5000 }).catch(() => {});
+  await p.waitForLoadState('networkidle').catch(() => {});
+}
+
+async function clickAnyYesNoButton(p: Page, yes = false) {
+  // Pages whose ONLY field is a single yesno render Yes/No as docassemble
+  // buttons that auto-submit; there's no Continue. Click "No" to advance.
+  const btn = p.locator(`button.btn-da:has-text("${yes ? 'Yes' : 'No'}"):visible`).first();
+  const n = await btn.count();
+  if (n > 0) {
+    await btn.click().catch(() => {});
+    await p.waitForLoadState('networkidle').catch(() => {});
+    return true;
+  }
+  return false;
+}
+
+test.describe('Strict-validator interview walker', () => {
+  test.setTimeout(900_000);
+
+  test('walks the petition; reports every silently-blocking page', async ({ page }) => {
+    // Prologue — get past district/debtor entry, which the walker can't
+    // synthesize because the SSN/county/state coupling is not generic.
+    await navigateToDebtorPage(page, SIMPLE_SINGLE);
+    await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+
+    const silentlyBlocked: string[] = [];
+    let lastHeading = '';
+    let sameHeadingStreak = 0;
+    const maxSteps = 600;
+
+    for (let step = 0; step < maxSteps; step++) {
+      const h = await getHeading(page);
+      const hLow = h.toLowerCase();
+
+      // Terminal states
+      if (
+        hLow.includes('voluntary petition for individuals filing for bankruptcy conclusion') ||
+        hLow.includes('form 101 output') ||
+        hLow.includes('your documents are ready') ||
+        hLow.includes('interview questions complete')
+      ) {
+        console.log(`[walker] reached terminal page after ${step} steps: "${h}"`);
+        break;
+      }
+
+      // Don't infinite-loop on docassemble Error
+      if (hLow === 'error') {
+        console.log(`[walker] hit Docassemble Error page at step ${step}`);
+        silentlyBlocked.push(`<error-page step=${step}>`);
+        break;
+      }
+
+      // Try strict Continue first
+      const handled = await fillVisibleRequiredFields(page);
+      if (handled) await page.waitForTimeout(250);
+
+      // If this is a button-only yesno page, click No
+      const advancedByButton = await clickAnyYesNoButton(page, false);
+      if (advancedByButton) {
+        sameHeadingStreak = 0;
+        lastHeading = h;
+        continue;
+      }
+
+      await clickContinueStrict(page);
+      await page.waitForTimeout(300);
+
+      const h2 = (await getHeading(page)).toLowerCase();
+      if (h2 === hLow) {
+        sameHeadingStreak += 1;
+        if (sameHeadingStreak === 1) {
+          // Try once more — sometimes the click was eaten by show-if JS
+          continue;
+        }
+        // Silent block confirmed. Record + escape with masked Continue.
+        if (!silentlyBlocked.includes(h)) {
+          silentlyBlocked.push(h);
+          console.log(`[walker] SILENT BLOCK at step ${step}: "${h}"`);
+        }
+        await clickContinue(page).catch(() => {});
+        await page.waitForLoadState('networkidle').catch(() => {});
+        sameHeadingStreak = 0;
+      } else {
+        sameHeadingStreak = 0;
+      }
+      lastHeading = h;
+    }
+
+    console.log(`\n=== STRICT-VALIDATOR WALKER SUMMARY ===`);
+    console.log(`Silently-blocked pages (count=${silentlyBlocked.length}):`);
+    for (const p of silentlyBlocked) console.log(`  - ${p}`);
+
+    // The test asserts the list is empty. Any blocker == a real-user
+    // hang of the same class as Lea's #98 fix.
+    expect(silentlyBlocked, `Pages silently blocking real-user Continue:\n${silentlyBlocked.map(s => '  - ' + s).join('\n')}`).toEqual([]);
+  });
+});

--- a/tests/strict-validator-walker.spec.ts
+++ b/tests/strict-validator-walker.spec.ts
@@ -56,25 +56,38 @@ async function fillVisibleRequiredFields(p: Page): Promise<boolean> {
       }
     });
 
-    // 2) yesno-radio groups — pick "No" if unselected
+    // 2) radio groups — pick "No"/False if unselected. CRITICAL: check the
+    //    LABEL's visibility (not the input). docassemble uses Bootstrap's
+    //    `btn-check` pattern where the input is intentionally hidden
+    //    (offsetParent === null) and the label carries both the click target
+    //    and the visible/active state. Setting .checked directly leaves the
+    //    form in a state the jQuery validator rejects on submit.
+    const seenGroups = new Set<string>();
     document.querySelectorAll('input[type="radio"]').forEach((r) => {
       const radio = r as HTMLInputElement;
-      if (radio.offsetParent === null) return;
       const name = radio.name;
-      if (!name) return;
-      const group = document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`);
-      const anyChecked = Array.from(group).some((g) => (g as HTMLInputElement).checked);
-      if (anyChecked) return;
-      const noOne = Array.from(group).find((g) => {
-        const v = (g as HTMLInputElement).value;
-        return v === 'False' || v === 'No' || v === 'false';
+      if (!name || seenGroups.has(name)) return;
+      seenGroups.add(name);
+      const group = Array.from(
+        document.querySelectorAll(`input[type="radio"][name="${CSS.escape(name)}"]`)
+      ) as HTMLInputElement[];
+      if (group.some((g) => g.checked)) return;
+      // Filter to inputs whose LABEL is visible (btn-check pattern means the
+      // input itself is hidden).
+      const visibleByLabel = group.filter((g) => {
+        if (!g.id) return false;
+        const lab = document.querySelector(`label[for="${CSS.escape(g.id)}"]`) as HTMLElement | null;
+        return !!lab && lab.offsetParent !== null;
       });
-      const target = (noOne || group[0]) as HTMLInputElement;
-      if (target) {
-        target.checked = true;
-        target.dispatchEvent(new Event('change', { bubbles: true }));
-        touched = true;
-      }
+      if (visibleByLabel.length === 0) return;
+      const noOne = visibleByLabel.find((g) => {
+        const v = g.value;
+        return v === 'False' || v === 'No' || v === 'false' || v === '0';
+      });
+      const target = noOne || visibleByLabel[0];
+      const lab = document.querySelector(`label[for="${CSS.escape(target.id)}"]`) as HTMLElement;
+      lab.click();
+      touched = true;
     });
 
     // 3) text/number/currency/date inputs — fill safe defaults
@@ -118,17 +131,20 @@ async function clickContinueStrict(p: Page) {
   await p.waitForLoadState('networkidle').catch(() => {});
 }
 
-async function clickAnyYesNoButton(p: Page, yes = false) {
+async function pageHasContinueButton(p: Page): Promise<boolean> {
+  return (await p.locator('#da-continue-button').count()) > 0;
+}
+
+async function clickYesNoButtonPage(p: Page, yes = false): Promise<boolean> {
   // Pages whose ONLY field is a single yesno render Yes/No as docassemble
-  // buttons that auto-submit; there's no Continue. Click "No" to advance.
-  const btn = p.locator(`button.btn-da:has-text("${yes ? 'Yes' : 'No'}"):visible`).first();
-  const n = await btn.count();
-  if (n > 0) {
-    await btn.click().catch(() => {});
-    await p.waitForLoadState('networkidle').catch(() => {});
-    return true;
-  }
-  return false;
+  // buttons (with a `name=<base64>` attribute) that auto-submit; there's no
+  // Continue button. Match any non-Continue button by its text.
+  const all = p.locator(`button[name]:has-text("${yes ? 'Yes' : 'No'}"):visible`);
+  const n = await all.count();
+  if (n === 0) return false;
+  await all.first().click().catch(() => {});
+  await p.waitForLoadState('networkidle').catch(() => {});
+  return true;
 }
 
 test.describe('Strict-validator interview walker', () => {
@@ -167,17 +183,24 @@ test.describe('Strict-validator interview walker', () => {
         break;
       }
 
-      // Try strict Continue first
+      // If this is a button-only yesno page (no Continue button), click No.
+      // This is NOT a Continue submission — it's docassemble's native yesno
+      // gate, which has no validator interaction. Always works.
+      if (!(await pageHasContinueButton(page))) {
+        const advanced = await clickYesNoButtonPage(page, false);
+        if (advanced) {
+          sameHeadingStreak = 0;
+          lastHeading = h;
+          continue;
+        }
+        // No Continue + no Yes/No buttons — unknown page type. Skip.
+        console.log(`[walker] step ${step}: no Continue and no Yes/No buttons on "${h}" — skipping`);
+        break;
+      }
+
+      // Normal page with Continue button: fill required fields, click STRICT
       const handled = await fillVisibleRequiredFields(page);
       if (handled) await page.waitForTimeout(250);
-
-      // If this is a button-only yesno page, click No
-      const advancedByButton = await clickAnyYesNoButton(page, false);
-      if (advancedByButton) {
-        sameHeadingStreak = 0;
-        lastHeading = h;
-        continue;
-      }
 
       await clickContinueStrict(page);
       await page.waitForTimeout(300);


### PR DESCRIPTION
Stops the drip-feed of customer reports for the same class of bug Lea most recently hit (#98) and the older customer bugs #54/56/57.

## Background

When the docassemble interview was originally written, conditional fields like \`mailing_street\` (\"show if has_other_mailing_address\") were written without \`required: False\`. That's the silent-block-Continue trap:

- The default jQuery validator runs with \`ignore: []\`.
- A field with no \`required: False\` is required.
- When \`show if:\` hides the field, it's *still in the DOM*, still required, and still validated.
- Continue silently fails with no visible error.

Real users see \"the Continue button doesn't work\" with nothing to click — exactly Lea's May-28 report (PR #98) and the older #54/56/57 reports.

## What this PR does

**Sweep 1 (319 fields)** — every \`fields:\` block in every question YAML is walked; any field that has \`show if:\` or \`hide if:\` and no \`required:\` set gets \`required: False\` inserted. Skips \`review:\`/\`table:\`/\`attachment:\` blocks (where \`required:\` is a docassemble loader error) and skips fields that already have \`required:\` set.

**Sweep 2 (4 fields)** — fields that had explicit \`required: True\` AND \`show if:\` are flipped to \`required: False\`. These were the trap the first sweep deliberately skipped, but they're functionally identical to the no-\`required:\` case: when hidden, the validator still demands a value.

Touched files:
- 101 (+6), 103A (+1), 103B (+25), 106AB (+153), 106EF (+10+2),
- 106G (+6), 106I (+16), 107 (+102), 2030 (+2), voluntary-petition (none).
- **323 fields total** across 9 YAML files.

## Verification

- **Strict-validator walker** (\`tests/strict-validator-walker.spec.ts\`): self-driving Playwright test that uses real-user click patterns (no \`:hidden\` override) and reports any page where Continue silently fails. Found 0 unresolved silent blocks after the sweeps.
- **Focused page probes** (\`tests/probe-cash-on-hand.spec.ts\`, \`tests/probe-personal-household.spec.ts\`, \`tests/probe-nonpriority-claim.spec.ts\`): three complex pages that the walker had at various points flagged. All three now pass under strict Continue.
- **Lea's strict-validator regressions** from PR #98 still pass.
- **Existing happy-path suite** (\`tests/dependents-main-flow.spec.ts\`): still passes (2.5m).

## Trade-offs / what to watch for

\`required: False\` on a *visible* conditional field means the asterisk and red-border-on-blank goes away when the user is on the show-if-true branch. The user could pick \"Other\" from a type dropdown and skip the \"specify other\" textbox; nothing prevents that. Downstream code uses \`getattr\`-with-default and tolerates empty values, but the PDF output could end up with blank fields where staff might expect content. Lea / Roxanne may want to spot-check the resulting PDF for a couple of common flows.

## Test plan

- [ ] Deploy to staging
- [ ] Run a full Schedule A/B walk-through; confirm no Continue surprises on the household-items page or the cash-on-hand page (those were the noisiest in the walker's initial run)
- [ ] Walk through a Schedule E/F nonpriority claim where the user picks \"Other\" as the type and *does* fill the specify-other field — confirm it flows through to the PDF
- [ ] Same for the 2030 attorney-disclosure \"other source\" path

🤖 Generated with [Claude Code](https://claude.com/claude-code)