### PR TITLE
Fix out-of-order priority gate / claim re-presentation from library picker (Roxanne June 4, items 2–3)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/creditor-library-picker.yml
+++ b/docassemble/BankruptcyClinic/data/questions/creditor-library-picker.yml
@@ -63,16 +63,17 @@ code: |
         if _ctype in PRIORITY_CREDITOR_TYPES:
           # Priority claim (Schedule E) — e.g. tax debt (IRS / NE Dept of
           # Revenue), domestic support. Route here, not to nonpriority.
-          _idx = len(prop.priority_claims)
-          prop.priority_claims.appendObject()
-          _claim = prop.priority_claims[_idx]
+          # appendObject() returns the new item and does NOT trigger
+          # gathering. len() on the ungathered list DID — selecting a
+          # priority-type library creditor (IRS / NE DoR) fired the
+          # "any PRIORITY unsecured debts?" gate right here, BEFORE secured
+          # creditors (Roxanne, June 4), instead of in the 106EF section.
+          _claim = prop.priority_claims.appendObject()
           _claim.type = _ctype
           prop.priority_claims.there_are_any = True
         else:
           # Nonpriority claim (Schedule F)
-          _idx = len(prop.nonpriority_claims)
-          prop.nonpriority_claims.appendObject()
-          _claim = prop.nonpriority_claims[_idx]
+          _claim = prop.nonpriority_claims.appendObject()  # no len(): see above
           if _ctype in [
             'Student loans',
             'Medical',


### PR DESCRIPTION
Roxanne (June 4): priority unsecured debts asked **before** secured creditors and then effectively again after; IRS/NE-DoR notice-address selections bounced back to the claim screen for state/amounts after Reporting.

Root cause: the creditor-library injection block called `len()` on the ungathered priority/nonpriority lists — `len()` triggers the gather, so selecting a priority-type library creditor (IRS / NE Dept of Revenue) fired the priority gate inside the Common Creditors step, out of flow order, and left half-injected items to re-present later. `appendObject()` returns the new item without touching gather state; injected items now complete inside the 106EF section where they belong.

Verified: canonical fuzz seeds (2 passed, 3.8m) + maximalist (5.2m) against the fix. **Roxanne should retest her exact path** (shared-library IRS selection) after deploy — the local test library doesn't mirror prod's entries.

Remaining from the June 4/5 emails, pending attorney answers (email drafted): MV exemption per-debtor logic, NE wildcard amount, SD caps, Schedule C checkbox convention, 107 Q4 multi-select, mortgage entry flow preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)