### PR TITLE
107 Q4: income sources multi-select (check all that apply)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
@@ -776,8 +776,7 @@ fields:
     choices:
       - Wages, commissions, bonuses, tips
       - Operating a business
-      - None
-    datatype: checkbox
+    datatype: checkboxes
     show if: financial_affairs.employed
     required: False
   - Gross Income: financial_affairs.current_gross_income
@@ -793,8 +792,7 @@ fields:
     choices:
       - Wages, commissions, bonuses, tips
       - Operating a business
-      - None
-    datatype: checkbox
+    datatype: checkboxes
     show if: financial_affairs.employed
     required: False
   - Gross Income: financial_affairs.last_gross_income
@@ -810,8 +808,7 @@ fields:
     choices:
       - Wages, commissions, bonuses, tips
       - Operating a business
-      - None
-    datatype: checkbox
+    datatype: checkboxes
     show if: financial_affairs.employed
     required: False
   - Gross Income: financial_affairs.before_gross_income
@@ -835,8 +832,7 @@ fields:
     choices:
       - Wages, commissions, bonuses, tips
       - Operating a business
-      - None
-    datatype: checkbox
+    datatype: checkboxes
     show if: financial_affairs.debtor2_employed
     required: False
   - Gross Income: financial_affairs.debtor2_current_gross_income
@@ -852,8 +848,7 @@ fields:
     choices:
       - Wages, commissions, bonuses, tips
       - Operating a business
-      - None
-    datatype: checkbox
+    datatype: checkboxes
     show if: financial_affairs.debtor2_employed
     required: False
   - Gross Income: financial_affairs.debtor2_last_gross_income
@@ -869,8 +864,7 @@ fields:
     choices:
       - Wages, commissions, bonuses, tips
       - Operating a business
-      - None
-    datatype: checkbox
+    datatype: checkboxes
     show if: financial_affairs.debtor2_employed
     required: False
   - Gross Income: financial_affairs.debtor2_before_gross_income
@@ -2350,24 +2344,20 @@ code: |
   fin['noRegularIncome'] = True if financial_affairs.employed == False else False
   fin['yesRegularIncome'] = True if financial_affairs.employed == True else False
   if financial_affairs.employed:
-    # *_income_sources use `datatype: checkbox` (singular) + choices, which
-    # docassemble renders as a SINGLE-select storing the chosen label as a
-    # plain str — NOT the DADict that `datatype: checkboxes` (plural) gives.
-    # So string equality is correct here; .get() crashes (str has no .get).
-    # Form-fidelity caveat: official 107 Q4 is "check all that apply" — a
-    # debtor with both wages AND a business can only record one. Flagged for
-    # attorney review; changing the datatype is a UI/semantics change.
-    fin['curr_D1_HasWages'] = financial_affairs.current_income_sources == 'Wages, commissions, bonuses, tips'
+    # *_income_sources are `datatype: checkboxes` (multi-select, matching the
+    # official 107 Q4 "check all that apply") — DADicts keyed by choice, so
+    # membership is .get(); both wages AND business can be True.
+    fin['curr_D1_HasWages'] = financial_affairs.current_income_sources.get('Wages, commissions, bonuses, tips', False)
     fin['curr_D1_GrossIncome'] = currency(financial_affairs.current_gross_income)
-    fin['curr_D1_HasBus'] = financial_affairs.current_income_sources == 'Operating a business'
+    fin['curr_D1_HasBus'] = financial_affairs.current_income_sources.get('Operating a business', False)
     fin['lastYear'] = financial_affairs.last_year
-    fin['last_D1_HasWages'] = financial_affairs.last_income_sources == 'Wages, commissions, bonuses, tips'
+    fin['last_D1_HasWages'] = financial_affairs.last_income_sources.get('Wages, commissions, bonuses, tips', False)
     fin['last_D1_GrossIncome'] = currency(financial_affairs.last_gross_income)
-    fin['last_D1_HasBus'] = financial_affairs.last_income_sources == 'Operating a business'
+    fin['last_D1_HasBus'] = financial_affairs.last_income_sources.get('Operating a business', False)
     fin['beforeYear'] = financial_affairs.before_year
-    fin['before_D1_HasWages'] = financial_affairs.before_income_sources == 'Wages, commissions, bonuses, tips'
+    fin['before_D1_HasWages'] = financial_affairs.before_income_sources.get('Wages, commissions, bonuses, tips', False)
     fin['before_D1_GrossIncome'] = currency(financial_affairs.before_gross_income)
-    fin['before_D1_HasBus'] = financial_affairs.before_income_sources == 'Operating a business'
+    fin['before_D1_HasBus'] = financial_affairs.before_income_sources.get('Operating a business', False)
 
   fin['noOtherIncome'] = True if financial_affairs.had_other_income == False else False
   fin['yesOtherIncome'] = True if financial_affairs.had_other_income == True else False
@@ -2430,19 +2420,18 @@ code: |
   # asks debtor2_employed / debtor2_had_other_income under `if len(debtor) > 1`),
   # so it must NOT be coupled to lived_elsewhere -- a joint filer who never
   # lived elsewhere would otherwise ship a blank Part 2 for debtor 2.
-  # *_income_sources use `datatype: checkbox` (singular) — single-select str,
-  # not a DADict; string equality is correct (see the D1 block note above).
+  # *_income_sources are checkboxes DADicts (see D1 note): membership = .get().
   if len(debtor) > 1:
     if financial_affairs.debtor2_employed:
-      fin['curr_D2_HasWages'] = financial_affairs.debtor2_current_income_sources == 'Wages, commissions, bonuses, tips'
+      fin['curr_D2_HasWages'] = financial_affairs.debtor2_current_income_sources.get('Wages, commissions, bonuses, tips', False)
       fin['curr_D2_GrossIncome'] = currency(financial_affairs.debtor2_current_gross_income)
-      fin['curr_D2_HasBus'] = financial_affairs.debtor2_current_income_sources == 'Operating a business'
-      fin['last_D2_HasWages'] = financial_affairs.debtor2_last_income_sources == 'Wages, commissions, bonuses, tips'
+      fin['curr_D2_HasBus'] = financial_affairs.debtor2_current_income_sources.get('Operating a business', False)
+      fin['last_D2_HasWages'] = financial_affairs.debtor2_last_income_sources.get('Wages, commissions, bonuses, tips', False)
       fin['last_D2_GrossIncome'] = currency(financial_affairs.debtor2_last_gross_income)
-      fin['last_D2_HasBus'] = financial_affairs.debtor2_last_income_sources == 'Operating a business'
-      fin['before_D2_HasWages'] = financial_affairs.debtor2_before_income_sources == 'Wages, commissions, bonuses, tips'
+      fin['last_D2_HasBus'] = financial_affairs.debtor2_last_income_sources.get('Operating a business', False)
+      fin['before_D2_HasWages'] = financial_affairs.debtor2_before_income_sources.get('Wages, commissions, bonuses, tips', False)
       fin['before_D2_GrossIncome'] = currency(financial_affairs.debtor2_before_gross_income)
-      fin['before_D2_HasBus'] = financial_affairs.debtor2_before_income_sources == 'Operating a business'
+      fin['before_D2_HasBus'] = financial_affairs.debtor2_before_income_sources.get('Operating a business', False)
     if financial_affairs.debtor2_had_other_income:
       fin['curr_D2_Source1'] = financial_affairs.debtor2_current_other_source_1
       fin['curr_D2_Amt1'] = currency(financial_affairs.debtor2_current_other_source_amount_1)


### PR DESCRIPTION
Resolves the form-fidelity caveat flagged in #106: official Form 107 Q4 is "check all that apply", but the interview's singular-`checkbox` datatype rendered single-select — a filer with both wage and business income could only record one. Fields converted to true `checkboxes`; builder reads converted to DADict membership; both boxes can now check for the same period.

Verified: maximalist E2E green (5.2m) driving the employed path through all three years with 107 PDF field checks.

**Deploy note:** in-flight sessions that answered these fields pre-deploy hold the old string values and would error at 107 assembly — restart those test sessions after deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)