### PR TITLE
NE wildcard → $5,970 (Phil-confirmed) + motor-vehicle exemption coverage & guard-rail finding

### DIFF
--- a/docassemble/BankruptcyClinic/data/static/exemptions.js
+++ b/docassemble/BankruptcyClinic/data/static/exemptions.js
@@ -12,7 +12,7 @@ const nebraskaExemptions = {
   tools: { law: 'Tools of the trade (Neb. Rev. Stat. § 25-1556(1)(d))', limit: 5970, amount: 0 },
   health_savings: { law: 'Health savings (Neb. Rev. Stat. § 8-1,131(2)(b))', limit: 25000, amount: 0 },
   life_insurance: { law: 'Life insurance proceeds (Neb. Rev. Stat. § 44-371)', limit: 100000, amount: 0 },
-  wildcard: { law: 'Wildcard (Neb. Rev. Stat. § 25-1552)', limit: 5000, amount: 0 },
+  wildcard: { law: 'Wildcard (Neb. Rev. Stat. § 25-1552)', limit: 5970, amount: 0 },
   clothing: { law: 'Clothing (Neb. Rev. Stat. § 25-1556(1)(b))', limit: 0, amount: 0 },
   personal_possessions: { law: 'Immediate personal possessions (Neb. Rev. Stat. § 25-1556(1)(a))', limit: 0, amount: 0 },
   health_aids: { law: 'Health aids (Neb. Rev. Stat. § 25-1556(1)(f))', limit: 0, amount: 0 },

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -301,7 +301,7 @@ def get_exemption_limits(user_state):
             'homestead_proceeds': 60000,
             'motor_vehicle': 5970,    # § 25-1556(1)(e), 2023 CPI-adjusted
             'household_goods': 3582,  # § 25-1556(1)(c), 2023 CPI-adjusted
-            'wildcard': 5000,
+            'wildcard': 5970,    # § 25-1552, 2023 CPI-adjusted (Phil Martin, Legal Aid of NE, June 2026)
             'clothing': 0,            # Unlimited
             'personal_possessions': 0, # Unlimited
             'health_aids': 0,         # Unlimited

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -48,6 +48,12 @@ export interface VehicleData {
   hasLoan: boolean;
   loanAmount?: string;
   otherInfo?: string;
+  /** 'Debtor 1 only' (default) / 'Debtor 2 only' / etc. — drives the
+   *  per-debtor motor-vehicle exemption rule (Phil's June 2026 scenario). */
+  owner?: string;
+  /** Claim the Motor Vehicle exemption on this vehicle. No prior test
+   *  exercised the vehicle-exemption path. */
+  claimMotorVehicle?: boolean;
 }
 
 export interface DepositData {

--- a/tests/mv-exemption-joint.spec.ts
+++ b/tests/mv-exemption-joint.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Motor-vehicle exemption, joint filers (Phil Martin, June 5 2026).
+ *
+ * Phil entered two cars in a married NE petition — his ($2K) and his wife's
+ * ($5K) — each claiming the Motor Vehicle exemption, and hit a validation
+ * error; he worked around it with Wildcard. Per his rule each debtor gets
+ * their OWN $5,970 motor-vehicle exemption (11 U.S.C. 522(m)); one spouse's
+ * cannot apply to the other's car.
+ *
+ * No prior test claimed a vehicle exemption at all, so this path was
+ * uncovered. These two cases pin the behavior:
+ *   POSITIVE — two cars, DIFFERENT owners (D1 / D2), both claim MV → must
+ *              pass and assemble (each spouse's own exemption is allowed).
+ *   NEGATIVE — two cars, SAME owner (both D1), both claim MV → must be
+ *              rejected at the vehicle screen (the one-per-debtor rule still
+ *              enforces).
+ */
+import { test, expect } from '@playwright/test';
+import { JOINT_COUPLE, TestScenario } from './fixtures';
+import { runFullInterview } from './navigation-helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+// NE joint couple (JOINT_COUPLE is SD; the NE motor-vehicle exemption only
+// exists in the NE exemption set). Two cars, both claiming Motor Vehicle.
+const NE_JOINT_BASE: TestScenario = {
+  ...JOINT_COUPLE,
+  name: 'ne-joint-mv',
+  district: 'District of Nebraska',
+  debtor: {
+    first: 'Philip', middle: 'S', last: 'Tester',
+    street: '100 Test Ave', city: 'Lincoln', state: 'Nebraska', zip: '68508',
+    countyIndex: 4, taxIdType: 'ssn', taxId: '444-55-6666',
+  },
+  spouse: {
+    first: 'Paula', middle: 'T', last: 'Tester',
+    street: '100 Test Ave', city: 'Lincoln', state: 'Nebraska', zip: '68508',
+    countyIndex: 4, taxIdType: 'ssn', taxId: '444-55-7777',
+  },
+};
+
+test.describe('Motor-vehicle exemption — joint filers', () => {
+  test.setTimeout(600_000);
+
+  test('POSITIVE: each spouse claims MV on their own car → assembles', async ({ page }) => {
+    const scenario: TestScenario = {
+      ...NE_JOINT_BASE,
+      property: {
+        vehicles: [
+          { make: 'Ford', model: 'Fusion', year: '2018', mileage: '60000', value: '2000',
+            state: 'Nebraska', hasLoan: false, owner: 'Debtor 1 only', claimMotorVehicle: true },
+          { make: 'Toyota', model: 'RAV4', year: '2019', mileage: '50000', value: '5000',
+            state: 'Nebraska', hasLoan: false, owner: 'Debtor 2 only', claimMotorVehicle: true },
+        ],
+      },
+    };
+    await runFullInterview(page, scenario);
+    await finishAndAssertAllPdfs(page);
+  });
+
+  // KNOWN GAP (discovered June 10 2026): the per-debtor "one vehicle" guard
+  // (issue #53, 106AB validation code) silently stopped firing when the
+  // vehicle question became `list collect: True`. Instrumentation showed the
+  // per-item validation runs, but a prior/current item's `who` reads as
+  // undefined at validation time (list-collect commits code:-choice fields
+  // after validation), so the cross-item ownership check never matches. A
+  // single debtor can therefore over-claim the motor-vehicle exemption on
+  // multiple cars, and there is no $5,970 dollar cap enforced at entry.
+  // Fix requires moving the check off per-item validation onto a screen where
+  // the list is fully gathered. Tracked here; flips green when fixed.
+  test.fixme('NEGATIVE: same debtor claims MV on two cars → should be rejected', async ({ page }) => {
+    const scenario: TestScenario = {
+      ...NE_JOINT_BASE,
+      property: {
+        vehicles: [
+          { make: 'Ford', model: 'Fusion', year: '2018', mileage: '60000', value: '2000',
+            state: 'Nebraska', hasLoan: false, owner: 'Debtor 1 only', claimMotorVehicle: true },
+          { make: 'Toyota', model: 'RAV4', year: '2019', mileage: '50000', value: '5000',
+            state: 'Nebraska', hasLoan: false, owner: 'Debtor 1 only', claimMotorVehicle: true },
+        ],
+      },
+    };
+    // The one-per-debtor validation_error fires on the second vehicle; the
+    // run cannot complete. Expect it to throw, and confirm the message is
+    // the motor-vehicle rule (not some unrelated failure).
+    let errText = '';
+    try {
+      await runFullInterview(page, scenario);
+      await finishAndAssertAllPdfs(page);
+    } catch (e) {
+      errText = (await page.locator('body').innerText().catch(() => '')) || String(e);
+    }
+    expect(errText.toLowerCase()).toContain('motor vehicle exemption may only be claimed for one vehicle');
+  });
+});

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -217,13 +217,15 @@ async function fillVehicle(page: Page, v: VehicleData, index: number) {
   await page.locator(`#${b64(`prop.ab_vehicles[${index}].milage`)}`).fill(v.mileage);
   // 'who' field — select "Debtor 1 only" (code-generated choices, always visible now)
   // On list-collect pages, field IDs use _field_X_Y format, so find by label text
+  const ownerChoice = v.owner ?? 'Debtor 1 only';
   const vehWhoSelect = page.locator(`select#${b64(`prop.ab_vehicles[${index}].who`)}`);
   if (await vehWhoSelect.count() > 0) {
-    await vehWhoSelect.selectOption('Debtor 1 only');
+    await vehWhoSelect.selectOption(ownerChoice);
   } else {
-    // List-collect: field is a radio rendered with encoded names — click first option by text
-    const debtorOnlyLabel = page.locator('label').filter({ hasText: 'Debtor 1 only' }).first();
-    if (await debtorOnlyLabel.count() > 0) await debtorOnlyLabel.click();
+    // List-collect: 'who' is a radio rendered with encoded names — click the
+    // matching option by its label text.
+    const ownerLabel = page.locator('label').filter({ hasText: ownerChoice }).first();
+    if (await ownerLabel.count() > 0) await ownerLabel.click();
   }
   await page.locator(`#${b64(`prop.ab_vehicles[${index}].current_value`)}`).fill(v.value);
   await page.locator(`#${b64(`prop.ab_vehicles[${index}].state`)}`).fill(v.state);
@@ -242,7 +244,19 @@ async function fillVehicle(page: Page, v: VehicleData, index: number) {
   if (await otherInfoField.count() > 0) {
     await otherInfoField.fill(v.otherInfo || 'N/A');
   }
-  await fillYesNoRadio(page, `prop.ab_vehicles[${index}].is_claiming_exemption`, false);
+  if (v.claimMotorVehicle) {
+    await fillYesNoRadio(page, `prop.ab_vehicles[${index}].is_claiming_exemption`, true);
+    await page.waitForTimeout(600);  // reveal show-if'd exemption fields
+    await fillById(page, b64(`prop.ab_vehicles[${index}].exemption_value`), v.value);
+    // exemption_laws is a show-if'd select with renamed _field_N id — drive by label.
+    const lawSel = page.getByLabel('Specific laws that allow exemption', { exact: true }).first();
+    const mvOption = (await lawSel.locator('option').allTextContents())
+      .find((o) => /motor vehicle/i.test(o));
+    if (!mvOption) throw new Error('Motor Vehicle option not in exemption_laws dropdown');
+    await lawSel.selectOption({ label: mvOption });
+  } else {
+    await fillYesNoRadio(page, `prop.ab_vehicles[${index}].is_claiming_exemption`, false);
+  }
 }
 
 async function fillDeposit(page: Page, dep: DepositData, index: number) {
@@ -274,17 +288,32 @@ export async function navigatePropertySection(page: Page, scenario: TestScenario
     await clickYesNoButton(page, 'prop.interests.there_are_any', false);
   }
 
-  // ── Vehicles ──
+  // ── Vehicles ── prop.vehicles (array) drives the multi-vehicle list-collect
+  // flow; prop.vehicle (single) is the legacy one-car shorthand.
+  const vehicleList = prop.vehicles ?? (prop.vehicle ? [prop.vehicle] : []);
   await waitForDaPageLoad(page);
-  if (prop.vehicle) {
+  if (vehicleList.length > 0) {
     await clickYesNoButton(page, 'prop.ab_vehicles.there_are_any', true);
-
-    await waitForDaPageLoad(page);
-    await fillVehicle(page, prop.vehicle, 0);
-    await clickContinue(page);
-    await waitForDaPageLoad(page);
-    await handleAnotherPage(page, 'prop.ab_vehicles.there_is_another');
-    await waitForDaPageLoad(page);
+    for (let vi = 0; vi < vehicleList.length; vi++) {
+      await waitForDaPageLoad(page);
+      await fillVehicle(page, vehicleList[vi], vi);
+      const isLast = vi === vehicleList.length - 1;
+      if (isLast) {
+        await clickContinue(page);
+        await waitForDaPageLoad(page);
+        await handleAnotherPage(page, 'prop.ab_vehicles.there_is_another');
+      } else {
+        // list-collect "Add another" — same idiom as the claims loop.
+        await page.evaluate(() => {
+          const btns = Array.from(document.querySelectorAll('button'))
+            .filter((b) => b.textContent?.includes('Add another') && (b as HTMLElement).offsetParent !== null);
+          if (btns.length > 0) btns[btns.length - 1].click();
+          else (document.getElementById('da-continue-button') as HTMLButtonElement | null)?.click();
+        });
+        await page.waitForLoadState('networkidle');
+      }
+      await waitForDaPageLoad(page);
+    }
   } else {
     await clickYesNoButton(page, 'prop.ab_vehicles.there_are_any', false);
   }


### PR DESCRIPTION
Acts on Phil Martin's June answers (items 1–2).

## ✅ Fixed: Nebraska wildcard $5,000 → $5,970
Per Phil Martin (Legal Aid of NE): the wildcard is now $5,970. Updated in both `objects.py` and `data/static/exemptions.js` (kept in sync; caps-sync gate green).

## ✅ Confirmed working: motor-vehicle exemption for joint filers
Phil's rule — each debtor claims one vehicle up to $5,970, no cross-application — is **already implemented** in the current build. New `tests/mv-exemption-joint.spec.ts` POSITIVE case (NE joint couple, each spouse claims MV on their own $2K/$5K car) assembles all PDFs. Phil's June-5 "second car rejected" error is **not reproducible** on the current build (it was an older build; the validator only ever blocked same-debtor claims).

No prior test claimed a vehicle exemption at all, so this added the first coverage: multi-vehicle support in `navigatePropertySection` (`prop.vehicles` array; the single `prop.vehicle` path is unchanged) and MV-claim support in the vehicle helper.

## ⚠️ Newly discovered gap (documented as `test.fixme`, not fixed here)
While reproducing Phil's scenario I found the per-debtor "one vehicle" guard (issue #53) **silently stopped enforcing** when the vehicle question became `list collect`. Container instrumentation: the per-item validation runs, but a prior/current item's `who` reads **undefined** at validation time (list-collect commits `code:`-choice fields *after* validation fires), so the cross-item ownership check never matches.

Consequences (both *too lenient* — opposite of Phil's complaint):
- One debtor can over-claim the MV exemption on multiple vehicles.
- No $5,970 dollar cap is enforced at vehicle entry.

Proper fix requires moving the check off per-item validation onto a screen where the list is fully gathered (with a way to route the user back to correct a vehicle) — scoped as its own task rather than rushed. The `NEGATIVE` test in the new spec documents it and flips green when fixed.

## Verification
- Maximalist E2E (joint, drives vehicles via the changed helper): green, 5.1m.
- New spec: POSITIVE passes, NEGATIVE = fixme (tracked gap).
- All static gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)