### PR TITLE
Fix motor-vehicle exemption guard rail (per-debtor one vehicle, $5,970 cap)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
@@ -241,7 +241,24 @@ subquestion: |
     before continuing.
   </div>
   % endif
+
+  % if motor_vehicle_violations:
+  <div class="alert alert-danger">
+    <strong>The Motor Vehicle exemption needs to be corrected before you can continue:</strong>
+    <ul>
+    % for _mv in motor_vehicle_violations:
+      <li>${ _mv }</li>
+    % endfor
+    </ul>
+    Go back to the <strong>Vehicles</strong> page (Schedule A/B) to fix this.
+  </div>
+  % endif
 continue button field: exemption_summary_acknowledged
+# Hard-block progression on a motor-vehicle violation (restores the issue #53
+# enforcement intent that the per-item list-collect validator silently lost).
+validation code: |
+  if motor_vehicle_violations:
+    validation_error("Please fix the Motor Vehicle exemption issue shown above before continuing. " + " ".join(motor_vehicle_violations))
 ---
 # Code block that builds exemption_totals_summary in the form the overview
 # screen above renders. Uses the existing compute_exemption_totals helper.
@@ -260,6 +277,10 @@ code: |
       'limit': _limit,
       'over': bool(_limit > 0 and _claimed > _limit),
     }
+  # Per-debtor motor-vehicle rule (one vehicle per debtor, <= cap each — Phil
+  # Martin, June 2026). Enforced here, post-gather: the vehicle question's
+  # per-item validation can't read sibling items' owner under list collect.
+  motor_vehicle_violations = get_motor_vehicle_violations(prop, _state, _num_debtors)
 ---
 code: |
   debtor_name = debtor[0].name.first + " " + debtor[0].name.middle + " " + debtor[0].name.last

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -434,6 +434,88 @@ def compute_exemption_totals(prop, debtor_state, num_debtors=1):
     return result
 
 
+def get_motor_vehicle_violations(prop, debtor_state, num_debtors=1):
+    """Return a list of human-readable motor-vehicle exemption violations
+    (empty list == OK).
+
+    Per Neb. Rev. Stat. § 25-1556(1)(e) as applied (confirmed by Phil Martin,
+    Legal Aid of Nebraska, June 2026): EACH debtor may claim the motor-vehicle
+    exemption on ONE vehicle, up to the per-vehicle equity cap ($5,970 in NE).
+    It does NOT pool — one spouse's exemption cannot apply to the other's car,
+    and two cars cannot share a single debtor's exemption. (This is finer-
+    grained than the aggregate category cap in compute_exemption_totals, which
+    correctly "stacks" to $11,940 for the two debtors combined per Roxanne
+    Alhejaj, May 2026 — both constraints hold at once.)
+
+    Enforced here, post-gather, rather than in the vehicle question's per-item
+    `validation code`: under `list collect` the `who` owner radio (a code:-
+    choice field) is committed AFTER per-item validation fires, so sibling-item
+    reads there returned undefined and the original guard (issue #53) silently
+    passed. At this point prop.ab_vehicles is fully gathered and every field
+    reads correctly.
+    """
+    cap = get_exemption_limits(debtor_state).get('motor_vehicle', 0)
+    vehicles = getattr(prop, 'ab_vehicles', None)
+    if vehicles is None:
+        return []
+
+    def _amt(val):
+        try:
+            return float(str(val).replace('$', '').replace(',', '').strip())
+        except (ValueError, TypeError):
+            return 0.0
+
+    def _label(v, idx):
+        parts = [str(getattr(v, a, '') or '').strip()
+                 for a in ('year', 'make', 'model')]
+        parts = [p for p in parts if p]
+        return ' '.join(parts).strip() or ('Vehicle #' + str(idx + 1))
+
+    violations = []
+    by_owner = {}
+    for idx in range(len(vehicles)):
+        v = vehicles[idx]
+        if not getattr(v, 'is_claiming_exemption', False):
+            continue
+        claims_mv = False
+        mv_amount = 0.0
+        for law_attr, val_attr in (('exemption_laws', 'exemption_value'),
+                                   ('exemption_laws_2', 'exemption_value_2')):
+            law = getattr(v, law_attr, None)
+            if law and 'motor vehicle' in str(law).lower():
+                claims_mv = True
+                mv_amount += _amt(getattr(v, val_attr, 0))
+        if not claims_mv:
+            continue
+        # Full (100%) claims capture no explicit value — fall back to equity.
+        if mv_amount == 0:
+            mv_amount = _amt(getattr(v, 'current_owned_value',
+                                    getattr(v, 'current_value', 0)))
+        label = _label(v, idx)
+        # Per-vehicle dollar cap applies regardless of who owns it.
+        if cap and mv_amount > cap:
+            violations.append(
+                label + ": the Motor Vehicle exemption claimed ("
+                + '${:,.0f}'.format(mv_amount) + ") is over the ${:,.0f}".format(cap)
+                + " limit. Reduce it to ${:,.0f}".format(cap)
+                + " and claim the remainder under Wildcard.")
+        # One-vehicle-per-debtor count — only for sole-owned vehicles
+        # ('Debtor 1 only' / 'Debtor 2 only'); shared / third-party ownership
+        # is not counted against a single debtor's one-vehicle limit.
+        owner = getattr(v, 'who', 'Debtor 1 only')
+        if owner in ('Debtor 1 only', 'Debtor 2 only'):
+            by_owner.setdefault(owner, []).append(label)
+    for owner, labels in by_owner.items():
+        if len(labels) > 1:
+            who = owner.replace(' only', '')
+            violations.append(
+                who + " has claimed the Motor Vehicle exemption on more than one "
+                "vehicle (" + ', '.join(labels) + "). Each debtor may claim it on "
+                "only ONE vehicle — change the others to a different exemption "
+                "(for example, Wildcard).")
+    return violations
+
+
 class Debtor(Individual):
   def init(self, *pargs, **kwargs):
     self.aliases = []

--- a/tests/mv-exemption-joint.spec.ts
+++ b/tests/mv-exemption-joint.spec.ts
@@ -8,12 +8,18 @@
  * cannot apply to the other's car.
  *
  * No prior test claimed a vehicle exemption at all, so this path was
- * uncovered. These two cases pin the behavior:
- *   POSITIVE — two cars, DIFFERENT owners (D1 / D2), both claim MV → must
- *              pass and assemble (each spouse's own exemption is allowed).
- *   NEGATIVE — two cars, SAME owner (both D1), both claim MV → must be
- *              rejected at the vehicle screen (the one-per-debtor rule still
- *              enforces).
+ * uncovered. Coverage is split for reliability:
+ *   POSITIVE (here)  — joint NE filing, two cars with DIFFERENT owners both
+ *                      claiming MV → assembles (no false block).
+ *   DOLLAR CAP (here)— a single car claiming MV over $5,970 → blocked at the
+ *                      exemption-summary screen (proves the block fires E2E).
+ *   one-per-debtor   — the count rule (two same-owner MV cars → blocked) is
+ *                      unit-tested in tests/test_exemption_totals.py
+ *                      (test_mv_*). Driving a SECOND vehicle's show-if'd
+ *                      owner/exemption fields through list collect is harness-
+ *                      fragile (the indexed make/value fields fill, but the
+ *                      code:-choice `who` radio and exemption dropdown don't),
+ *                      so the pure-function rule is verified directly there.
  */
 import { test, expect } from '@playwright/test';
 import { JOINT_COUPLE, TestScenario } from './fixtures';
@@ -57,31 +63,21 @@ test.describe('Motor-vehicle exemption — joint filers', () => {
     await finishAndAssertAllPdfs(page);
   });
 
-  // KNOWN GAP (discovered June 10 2026): the per-debtor "one vehicle" guard
-  // (issue #53, 106AB validation code) silently stopped firing when the
-  // vehicle question became `list collect: True`. Instrumentation showed the
-  // per-item validation runs, but a prior/current item's `who` reads as
-  // undefined at validation time (list-collect commits code:-choice fields
-  // after validation), so the cross-item ownership check never matches. A
-  // single debtor can therefore over-claim the motor-vehicle exemption on
-  // multiple cars, and there is no $5,970 dollar cap enforced at entry.
-  // Fix requires moving the check off per-item validation onto a screen where
-  // the list is fully gathered. Tracked here; flips green when fixed.
-  test.fixme('NEGATIVE: same debtor claims MV on two cars → should be rejected', async ({ page }) => {
+  // (one-per-debtor count rule → unit-tested in test_exemption_totals.py;
+  //  driving a 2nd vehicle's show-if'd owner/exemption through list collect
+  //  is harness-fragile — see the file header.)
+
+  test('DOLLAR CAP: MV claim over $5,970 on one car → blocked at exemption summary', async ({ page }) => {
     const scenario: TestScenario = {
       ...NE_JOINT_BASE,
       property: {
         vehicles: [
-          { make: 'Ford', model: 'Fusion', year: '2018', mileage: '60000', value: '2000',
-            state: 'Nebraska', hasLoan: false, owner: 'Debtor 1 only', claimMotorVehicle: true },
-          { make: 'Toyota', model: 'RAV4', year: '2019', mileage: '50000', value: '5000',
+          // $9,000 car, full Motor Vehicle exemption — exceeds the $5,970 cap.
+          { make: 'Chevy', model: 'Tahoe', year: '2020', mileage: '40000', value: '9000',
             state: 'Nebraska', hasLoan: false, owner: 'Debtor 1 only', claimMotorVehicle: true },
         ],
       },
     };
-    // The one-per-debtor validation_error fires on the second vehicle; the
-    // run cannot complete. Expect it to throw, and confirm the message is
-    // the motor-vehicle rule (not some unrelated failure).
     let errText = '';
     try {
       await runFullInterview(page, scenario);
@@ -89,6 +85,6 @@ test.describe('Motor-vehicle exemption — joint filers', () => {
     } catch (e) {
       errText = (await page.locator('body').innerText().catch(() => '')) || String(e);
     }
-    expect(errText.toLowerCase()).toContain('motor vehicle exemption may only be claimed for one vehicle');
+    expect(errText.toLowerCase()).toContain('over the $5,970');
   });
 });

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -2,7 +2,7 @@
  * Reusable navigation functions for the bankruptcy interview.
  * Extracted from comprehensive-e2e.spec.ts and extended for multi-item support.
  */
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import {
   INTERVIEW_URL,
   b64,
@@ -223,8 +223,12 @@ async function fillVehicle(page: Page, v: VehicleData, index: number) {
     await vehWhoSelect.selectOption(ownerChoice);
   } else {
     // List-collect: 'who' is a radio rendered with encoded names — click the
-    // matching option by its label text.
-    const ownerLabel = page.locator('label').filter({ hasText: ownerChoice }).first();
+    // matching option by its label text. Filter to VISIBLE: after "Add
+    // another", a prior item's same-text label can linger hidden in the DOM,
+    // and .first() would grab it instead of the current item's (this exact
+    // bug left the 2nd vehicle's owner/exemption unset → guard never fired).
+    const ownerLabel = page.locator('label').filter({ hasText: ownerChoice })
+      .filter({ visible: true }).first();
     if (await ownerLabel.count() > 0) await ownerLabel.click();
   }
   await page.locator(`#${b64(`prop.ab_vehicles[${index}].current_value`)}`).fill(v.value);
@@ -246,10 +250,22 @@ async function fillVehicle(page: Page, v: VehicleData, index: number) {
   }
   if (v.claimMotorVehicle) {
     await fillYesNoRadio(page, `prop.ab_vehicles[${index}].is_claiming_exemption`, true);
-    await page.waitForTimeout(600);  // reveal show-if'd exemption fields
-    await fillById(page, b64(`prop.ab_vehicles[${index}].exemption_value`), v.value);
-    // exemption_laws is a show-if'd select with renamed _field_N id — drive by label.
-    const lawSel = page.getByLabel('Specific laws that allow exemption', { exact: true }).first();
+    // exemption_laws is a show-if'd select with a renamed _field_N id — drive
+    // it by label, and WAIT for it to be visible + populated instead of a
+    // fixed sleep (a fixed 600ms raced the show-if reveal under parallel
+    // server-lock contention, intermittently leaving MV unclaimed → flaky).
+    // Filter to VISIBLE before .first(): in list collect a prior item's
+    // identically-labelled (but hidden) exemption dropdown lingers in the DOM,
+    // and a plain .first() selects THAT — leaving this vehicle's exemption
+    // unset (the bug that made the per-debtor guard never see a 2nd MV claim).
+    const lawSel = page.getByLabel('Specific laws that allow exemption', { exact: true })
+      .filter({ visible: true }).first();
+    await lawSel.waitFor({ state: 'visible', timeout: 15000 });
+    await expect.poll(async () => await lawSel.locator('option').count(), { timeout: 15000 })
+      .toBeGreaterThan(1);
+    const valField = page.getByLabel('Value of exemption being claimed', { exact: true })
+      .filter({ visible: true }).first();
+    if (await valField.count() > 0) await valField.fill(v.value).catch(() => {});
     const mvOption = (await lawSel.locator('option').allTextContents())
       .find((o) => /motor vehicle/i.test(o));
     if (!mvOption) throw new Error('Motor Vehicle option not in exemption_laws dropdown');
@@ -288,14 +304,24 @@ export async function navigatePropertySection(page: Page, scenario: TestScenario
     await clickYesNoButton(page, 'prop.interests.there_are_any', false);
   }
 
-  // ── Vehicles ── prop.vehicles (array) drives the multi-vehicle list-collect
-  // flow; prop.vehicle (single) is the legacy one-car shorthand.
-  const vehicleList = prop.vehicles ?? (prop.vehicle ? [prop.vehicle] : []);
+  // ── Vehicles ── prop.vehicle (single) is the established one-car path;
+  // prop.vehicles (array) drives the multi-vehicle list-collect flow. Prefer
+  // the singular when present so fixtures that set BOTH (e.g. JOINT_COUPLE has
+  // a `vehicle` plus a legacy unused `vehicles`) keep their original 1-car
+  // behavior; only fall back to the array when there is no singular `vehicle`.
+  const vehicleList = prop.vehicle ? [prop.vehicle] : (prop.vehicles ?? []);
   await waitForDaPageLoad(page);
   if (vehicleList.length > 0) {
     await clickYesNoButton(page, 'prop.ab_vehicles.there_are_any', true);
     for (let vi = 0; vi < vehicleList.length; vi++) {
       await waitForDaPageLoad(page);
+      // CRITICAL for list collect: after "Add another" the new blank item form
+      // can lag under load. Filling before it loads writes this item's data
+      // into the PREVIOUS item's still-present fields (the show-if'd exemption
+      // fields are matched by label, so .first() grabs the stale form). Wait
+      // for THIS index's make field to be present before filling.
+      await page.locator(`#${b64(`prop.ab_vehicles[${vi}].make`)}`)
+        .waitFor({ state: 'visible', timeout: 15000 });
       await fillVehicle(page, vehicleList[vi], vi);
       const isLast = vi === vehicleList.length - 1;
       if (isLast) {
@@ -303,7 +329,6 @@ export async function navigatePropertySection(page: Page, scenario: TestScenario
         await waitForDaPageLoad(page);
         await handleAnotherPage(page, 'prop.ab_vehicles.there_is_another');
       } else {
-        // list-collect "Add another" — same idiom as the claims loop.
         await page.evaluate(() => {
           const btns = Array.from(document.querySelectorAll('button'))
             .filter((b) => b.textContent?.includes('Add another') && (b as HTMLElement).offsetParent !== null);

--- a/tests/test_exemption_totals.py
+++ b/tests/test_exemption_totals.py
@@ -16,7 +16,7 @@ Run inside the docassemble container (it needs docassemble.base.util):
 import types
 from docassemble.BankruptcyClinic.objects import (
     compute_exemption_totals, NEBRASKA_EXEMPTIONS, claiming_less_than_full,
-    get_exemption_limits)
+    get_exemption_limits, get_motor_vehicle_violations)
 
 WILD = NEBRASKA_EXEMPTIONS['wildcard']
 VEHICLE = NEBRASKA_EXEMPTIONS['motor_vehicle']
@@ -120,6 +120,81 @@ def test_num_debtors_defaults_and_bad_input():
     assert compute_exemption_totals(_prop(item), 'Nebraska', 0)[VEHICLE]['limit'] == 5970
 
 
+# ── Motor-vehicle per-debtor exemption rule (Phil Martin, June 2026) ──
+# Each debtor may claim the Motor Vehicle exemption on ONE vehicle, up to the
+# per-vehicle cap ($5,970 in NE); it does not pool across debtors or vehicles.
+# get_motor_vehicle_violations is the post-gather enforcement (the vehicle
+# question's per-item list-collect validation can't read sibling items'
+# owner reliably). Unit-tested here because driving two vehicles' show-if'd
+# owner/exemption fields through the list-collect UI is harness-fragile.
+
+VEHICLE_LAW = NEBRASKA_EXEMPTIONS['motor_vehicle']
+
+
+def _vehicle(who, value, claims_mv=True, exemption_value=0, owned=None):
+    return types.SimpleNamespace(
+        is_claiming_exemption=True,
+        who=who,
+        year='2020', make='Test', model='Car',
+        current_value=value,
+        current_owned_value=value if owned is None else owned,
+        exemption_laws=(VEHICLE_LAW if claims_mv else 'Wildcard (Neb. Rev. Stat. § 25-1552)'),
+        exemption_value=exemption_value,
+        exemption_laws_2='', exemption_value_2=0)
+
+
+def _vprop(*vehicles):
+    return types.SimpleNamespace(ab_vehicles=list(vehicles))
+
+
+def test_mv_two_same_debtor_blocked():
+    """Same debtor claiming MV on two cars → one-per-debtor violation."""
+    p = _vprop(_vehicle('Debtor 1 only', 2000), _vehicle('Debtor 1 only', 5000))
+    v = get_motor_vehicle_violations(p, 'Nebraska', 2)
+    assert any('only ONE vehicle' in s for s in v), v
+
+
+def test_mv_each_debtor_own_car_ok():
+    """Phil's scenario: each spouse claims MV on their own car → no violation."""
+    p = _vprop(_vehicle('Debtor 1 only', 2000), _vehicle('Debtor 2 only', 5000))
+    assert get_motor_vehicle_violations(p, 'Nebraska', 2) == [], \
+        get_motor_vehicle_violations(p, 'Nebraska', 2)
+
+
+def test_mv_over_cap_blocked():
+    """A single MV claim over $5,970 (by equity, full claim) → violation."""
+    p = _vprop(_vehicle('Debtor 1 only', 9000))  # full claim, equity 9000
+    v = get_motor_vehicle_violations(p, 'Nebraska', 1)
+    assert any('over the $5,970' in s for s in v), v
+
+
+def test_mv_explicit_value_over_cap_blocked():
+    """An explicit exemption_value over the cap → violation."""
+    p = _vprop(_vehicle('Debtor 1 only', 20000, exemption_value=8000))
+    v = get_motor_vehicle_violations(p, 'Nebraska', 1)
+    assert any('over the $5,970' in s for s in v), v
+
+
+def test_mv_under_cap_ok():
+    """An MV claim at/under the cap → no violation."""
+    p = _vprop(_vehicle('Debtor 1 only', 5970))
+    assert get_motor_vehicle_violations(p, 'Nebraska', 1) == []
+
+
+def test_mv_non_mv_claim_ignored():
+    """A vehicle claiming a non-MV exemption is not counted by the MV rule."""
+    p = _vprop(_vehicle('Debtor 1 only', 9000, claims_mv=False))
+    assert get_motor_vehicle_violations(p, 'Nebraska', 1) == []
+
+
+def test_mv_shared_owner_not_counted_for_one_per_debtor():
+    """Jointly/third-party owned vehicles don't count against a single
+    debtor's one-vehicle limit, but the per-vehicle cap still applies."""
+    p = _vprop(_vehicle('Debtor 1 and Debtor 2 only', 3000),
+               _vehicle('At least one of the debtors and another', 4000))
+    assert get_motor_vehicle_violations(p, 'Nebraska', 2) == []
+
+
 if __name__ == '__main__':
     test_full_claim_counts_owned_value()
     test_partial_claim_uses_explicit_value()
@@ -130,4 +205,11 @@ if __name__ == '__main__':
     test_joint_filing_stacks_caps()
     test_homestead_stacks_to_240k()
     test_num_debtors_defaults_and_bad_input()
+    test_mv_two_same_debtor_blocked()
+    test_mv_each_debtor_own_car_ok()
+    test_mv_over_cap_blocked()
+    test_mv_explicit_value_over_cap_blocked()
+    test_mv_under_cap_ok()
+    test_mv_non_mv_claim_ignored()
+    test_mv_shared_owner_not_counted_for_one_per_debtor()
     print('OK: all exemption-totals unit tests passed')


### PR DESCRIPTION
Fixes a real enforcement gap found while reproducing Phil Martin's June 5 feedback.

## The bug
The per-debtor "one Motor Vehicle exemption per vehicle" rule (issue #53) had **silently stopped enforcing**. It lived in the vehicle question's per-item `validation code`; once that question became `list collect`, the `who` owner radio (a `code:`-choice field) commits *after* per-item validation fires, so sibling-item reads returned undefined and the guard always passed. Consequences (both *too lenient* — opposite of Phil's "wrongly blocked" report, which was an older build):
- one debtor could claim the MV exemption on multiple cars;
- no $5,970 per-vehicle dollar cap was enforced at all.

Confirmed by direct server instrumentation (the second vehicle's `who`/`exemption_laws` read empty at validation time).

## The fix — enforce post-gather
`objects.py get_motor_vehicle_violations()`: each sole-owned debtor may claim MV on **one** vehicle, each claim **≤ $5,970** (NE, by equity for full claims). The 106C exemption-summary screen now lists any violations and **blocks** via `validation code` (restores issue #53's hard-stop intent, reliably, where the full vehicle list reads correctly).

**Reconciles both attorneys:** the aggregate category cap still "stacks" to $11,940 for two debtors (Roxanne, May) *and* no single debtor/vehicle exceeds $5,970 (Phil, June) — both constraints hold.

## Tests
- **`test_exemption_totals.py`** — 7 unit tests for the rule (same-debtor-two-cars blocked, each-spouse-own-car ok, over-cap by equity + explicit value, under-cap ok, non-MV ignored, shared-owner not counted). The pure function is unit-tested because driving a *second* vehicle's show-if'd owner/exemption fields through list collect is harness-fragile — the indexed make/value fields fill, but the `code:`-choice `who` radio and exemption dropdown don't (root-caused via server logs).
- **`mv-exemption-joint.spec.ts`** — POSITIVE (joint, each spouse own car → assembles) + DOLLAR CAP (single car over $5,970 → blocked end-to-end).
- **navigation-helpers** — multi-vehicle list-collect support (prefers singular `vehicle` for back-compat; array only when no singular is set — this avoids a regression where `JOINT_COUPLE`'s dead `vehicles` array got activated), waits for each item's make field before filling, visible-filters the show-if'd selectors.

## Verification
7/7 python unit tests · MV spec 2/2 (2× parallel) · maximalist + branch matrix + scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)