### PR TITLE
Test infra: container-per-worker pool — fixes parallel-run flakiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,29 @@ crashes live). When testing a fix, drive the *actual failing branch*. Deploy
 locally with `./deploy.sh` (installs into the `docassemble` Docker container);
 read real tracebacks from `docker exec docassemble tail /usr/share/docassemble/log/docassemble.log`.
 
+### Parallel runs: one container per worker
+
+A docassemble container is the **unit of concurrency**, not the host. Pointing
+several Playwright workers at ONE container overloads its single-process server
+(`processes = 1` in `docassemble.ini`) and its DB connections — manifesting as
+slow page renders (30s `locator.click` timeouts) or `psycopg2 SSL error:
+decryption failed` error pages. This is the *only* source of parallel-run
+flakiness; the product is unaffected (serial runs are 100% clean). **Bumping
+the container's `processes` does NOT fix it — it makes the DB errors worse.**
+
+The fix is **container-per-worker**: each worker gets its own container.
+- `./scripts/test-container-pool.sh up` clones the working `datest` container
+  (NOT a fresh `jhpyle/docassemble` pull — newer image, deploy.sh can't drive
+  it) into `datest2`/`datest3` (:8910/:8920) and deploys the package to each.
+- `npm run test:pool` runs the suite `--workers=4` with
+  `DA_CONTAINERS=<4 urls>`; `tests/helpers.ts` picks a base URL per worker by
+  `TEST_PARALLEL_INDEX`. Proven: specs that were flaky at workers=3-on-1 pass
+  clean first-try at workers=4-across-4.
+- `./scripts/test-container-pool.sh down` removes the clones.
+- After a code change, redeploy the **whole pool** (`./deploy.sh`,
+  `DA_CONTAINER=datest/datest2/datest3 ./deploy.sh`) or `… pool deploy`.
+Without `DA_CONTAINERS`, everything falls back to single-`BASE_URL` behavior.
+
 **Every scenario/regression test must run ALL THE WAY THROUGH to PDF assembly.**
 A passing mid-interview screen proves a screen, not the deliverable; crashes
 like the 106AB grand-total sum surface only at assembly, and a mid-interview fix

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "BASE_URL=http://localhost:8080 playwright test",
     "test:local": "BASE_URL=http://localhost:8080 playwright test",
     "test:remote": "BASE_URL=https://docassemble2.metatheria.solutions playwright test",
+    "test:pool": "DA_CONTAINERS=\"$(./scripts/test-container-pool.sh env)\" playwright test --workers=4",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",
     "test:ui": "playwright test --ui",

--- a/scripts/test-container-pool.sh
+++ b/scripts/test-container-pool.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Stand up (or refresh) a pool of docassemble containers for parallel testing,
+# one per Playwright worker — the fix for parallel-run flakiness.
+#
+# A single docassemble instance is the unit of concurrency: pointing several
+# workers at one container overloads its single-process server and DB
+# connections (slow renders / "SSL decryption failed" errors). Giving each
+# worker its OWN container removes the contention entirely (proven: the specs
+# that were flaky at workers=3-on-one-container pass clean first-try at
+# workers=4 across 4 containers).
+#
+# New containers are CLONED from an existing working container (docker commit)
+# rather than pulled fresh — a fresh `jhpyle/docassemble` pull uses a newer
+# image layout that deploy.sh doesn't drive. After cloning, the package is
+# (re)deployed into each clone (the clone's fresh DB loses the package
+# registration even though the files are present).
+#
+# Usage:
+#   ./scripts/test-container-pool.sh up      # create datest2/3 (ports 8910/8920) + deploy
+#   ./scripts/test-container-pool.sh deploy  # redeploy current package to the whole pool
+#   ./scripts/test-container-pool.sh down     # remove the extra clones
+#   ./scripts/test-container-pool.sh env      # print the DA_CONTAINERS line to export
+#
+# Then run the suite across the pool:
+#   DA_CONTAINERS="$(./scripts/test-container-pool.sh env)" npx playwright test --workers=4
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+DOCKER="sg docker -c"
+BASE_CONTAINER="${DA_BASE_CONTAINER:-datest}"     # an existing working container to clone
+CLONES=("datest2:8910" "datest3:8920")            # name:hostport
+POOL_URLS="http://localhost:8080,http://localhost:8900,http://localhost:8910,http://localhost:8920"
+
+case "${1:-}" in
+  up)
+    echo "Cloning $BASE_CONTAINER -> dabank-test:clone"
+    $DOCKER "docker commit $BASE_CONTAINER dabank-test:clone" >/dev/null
+    for spec in "${CLONES[@]}"; do
+      name="${spec%%:*}"; port="${spec##*:}"
+      $DOCKER "docker rm -f $name" >/dev/null 2>&1 || true
+      echo "Starting $name on :$port"
+      $DOCKER "docker run -d --name $name -p ${port}:80 dabank-test:clone" >/dev/null
+    done
+    echo "Waiting for clones to serve..."
+    for spec in "${CLONES[@]}"; do
+      port="${spec##*:}"
+      until curl -s -o /dev/null -w '%{http_code}' --max-time 8 "http://localhost:${port}/" 2>/dev/null | grep -q 200; do sleep 10; done
+    done
+    "$0" deploy
+    ;;
+  deploy)
+    for c in datest2 datest3; do
+      $DOCKER "docker ps --format '{{.Names}}'" | grep -qx "$c" && { echo "deploy -> $c"; DA_CONTAINER="$c" ./deploy.sh >/dev/null 2>&1 && echo "  ok"; }
+    done
+    echo "(also redeploy the base pool members 'docassemble' and '$BASE_CONTAINER' with ./deploy.sh / DA_CONTAINER=$BASE_CONTAINER ./deploy.sh as needed)"
+    ;;
+  down)
+    for spec in "${CLONES[@]}"; do name="${spec%%:*}"; $DOCKER "docker rm -f $name" >/dev/null 2>&1 && echo "removed $name"; done
+    ;;
+  env)
+    echo "$POOL_URLS"
+    ;;
+  *)
+    echo "usage: $0 {up|deploy|down|env}"; exit 2;;
+esac

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,7 +1,20 @@
 import { Page } from '@playwright/test';
 
-/** Base URL for the docassemble interview */
-const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+/** Base URL for the docassemble interview.
+ *
+ * A docassemble container is the unit of concurrency — pointing several
+ * Playwright workers at ONE container overloads its single-process server and
+ * its DB connections (slow renders / "SSL decryption failed" errors), which is
+ * the sole source of parallel-run flakiness (the product is unaffected; serial
+ * runs are 100% clean). The robust fix is container-per-worker: set
+ * DA_CONTAINERS to a comma-separated pool of base URLs and each worker picks
+ * one by its TEST_PARALLEL_INDEX, so no two workers share a container.
+ * Falls back to the single BASE_URL when DA_CONTAINERS is unset. */
+const _POOL = (process.env.DA_CONTAINERS || '').split(',').map(s => s.trim()).filter(Boolean);
+const _WORKER = parseInt(process.env.TEST_PARALLEL_INDEX || '0', 10) || 0;
+const BASE_URL = _POOL.length > 0
+  ? _POOL[_WORKER % _POOL.length]
+  : (process.env.BASE_URL || 'http://localhost:8080');
 const INTERVIEW_PACKAGE = process.env.INTERVIEW_PACKAGE || 'docassemble.BankruptcyClinic:data/questions/voluntary-petition.yml';
 export const INTERVIEW_URL =
   `${BASE_URL}/interview?i=${INTERVIEW_PACKAGE}#page1`;


### PR DESCRIPTION
Root-causes and fixes the parallel-suite flakiness (the "4 flaky" in the comprehensive run).

## What it actually was — NOT the host
The box has 24 cores / 62 GB, all idle. A **docassemble container is the unit of concurrency**: it serves with `processes = 1` (one Python process). Pointing several Playwright workers at one container overloads its server and DB connection layer → 30 s `locator.click` timeouts, or `psycopg2 OperationalError: SSL error: decryption failed` error pages.

**Bumping the container's `processes` does NOT help — it makes it worse** (verified: processes=4 introduced the psycopg2 SSL errors). The product is unaffected — serial runs and 50/50 fuzz seeds are 100% clean; every flaky failure was infra, never a product error.

## The fix — one container per worker
- `tests/helpers.ts`: `BASE_URL` is chosen per worker from a `DA_CONTAINERS` pool by `TEST_PARALLEL_INDEX` (falls back to single `BASE_URL` when unset — fully backward compatible).
- `scripts/test-container-pool.sh up|deploy|down|env`: clones the working `datest` container (a fresh `jhpyle/docassemble` pull is a newer image `deploy.sh` can't drive — the snag that delayed this) into `datest2`/`datest3` and deploys the package to each.
- `npm run test:pool`: `DA_CONTAINERS="<4 urls>" playwright test --workers=4`.
- `CLAUDE.md`: documents the mechanism + workflow.

## Proof
The specs that were flaky at workers=3-on-1-container pass **clean first-try at workers=4-across-4-containers, no retries**. Full 34-spec suite: **133 passed + 4 flaky → 137 passed + 0 flaky** (4 remaining skips are intentional `test.skip`/`test.fixme` markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)