### PR TITLE
Notice-only creditors + fix the deleted-all-claims dead end

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
@@ -262,6 +262,34 @@ fields:
     maxlength: 5
     show if: prop.priority_claims[i].has_notify
     required: False
+# Roxanne UAT (June 2026, follow-up): deleting EVERY row on this screen used
+# to silently re-render it demanding a fresh claim (gather() had latched
+# there_are_any=True from the picker-injected rows). An emptied list is an
+# explicit "I have none" — record it so the flow moves on.
+validation code: |
+  if len(prop.priority_claims) == 0:
+    prop.priority_claims.there_are_any = False
+    prop.priority_claims.gathered = True
+script: |
+  <script>
+    // docassemble's list collect DISABLES Continue when every row is deleted,
+    // silently trapping the filer ("Software will NOT let me move on" —
+    // Roxanne UAT, June 2026). Deleting every row is a legitimate "I have
+    // none": re-enable Continue so the form submits; the server-side
+    // validation code records there_are_any=False and the flow moves on.
+    // Poll rather than delegate: the core delete handlers `return false`,
+    // which stops propagation, so a document-delegated click handler never
+    // fires. The poll is a no-op on pages without collect rows, and the
+    // timer is replaced on each screen render.
+    if (window.daZeroClaimsTimer) { clearInterval(window.daZeroClaimsTimer); }
+    window.daZeroClaimsTimer = setInterval(function () {
+      var live = $('button.dacollectremove:visible, button.dacollectremoveexisting:visible').length;
+      var removed = $('button.dacollectunremove:visible').length;
+      if (live === 0 && removed > 0) {
+        $('#da-continue-button').prop('disabled', false);
+      }
+    }, 400);
+  </script>
 list collect: True
 ---
 table: prop_nonpriority_claims_table
@@ -527,6 +555,33 @@ fields:
     maxlength: 5
     show if: prop.nonpriority_claims[i].has_notify
     required: False
+# Same escape hatch as Schedule E: the subquestion promises "If you have none
+# to add, you can continue past this section" — deleting the blank row and
+# continuing must actually work.
+validation code: |
+  if len(prop.nonpriority_claims) == 0:
+    prop.nonpriority_claims.there_are_any = False
+    prop.nonpriority_claims.gathered = True
+script: |
+  <script>
+    // docassemble's list collect DISABLES Continue when every row is deleted,
+    // silently trapping the filer ("Software will NOT let me move on" —
+    // Roxanne UAT, June 2026). Deleting every row is a legitimate "I have
+    // none": re-enable Continue so the form submits; the server-side
+    // validation code records there_are_any=False and the flow moves on.
+    // Poll rather than delegate: the core delete handlers `return false`,
+    // which stops propagation, so a document-delegated click handler never
+    // fires. The poll is a no-op on pages without collect rows, and the
+    // timer is replaced on each screen render.
+    if (window.daZeroClaimsTimer) { clearInterval(window.daZeroClaimsTimer); }
+    window.daZeroClaimsTimer = setInterval(function () {
+      var live = $('button.dacollectremove:visible, button.dacollectremoveexisting:visible').length;
+      var removed = $('button.dacollectunremove:visible').length;
+      if (live === 0 && removed > 0) {
+        $('#da-continue-button').prop('disabled', false);
+      }
+    }, 400);
+  </script>
 list collect: True
 ---
 id: schedule_ef_review

--- a/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
@@ -268,8 +268,7 @@ fields:
 # explicit "I have none" — record it so the flow moves on.
 validation code: |
   if len(prop.priority_claims) == 0:
-    prop.priority_claims.there_are_any = False
-    prop.priority_claims.gathered = True
+    mark_list_emptied(prop.priority_claims)
 script: |
   <script>
     // docassemble's list collect DISABLES Continue when every row is deleted,
@@ -560,8 +559,7 @@ fields:
 # continuing must actually work.
 validation code: |
   if len(prop.nonpriority_claims) == 0:
-    prop.nonpriority_claims.there_are_any = False
-    prop.nonpriority_claims.gathered = True
+    mark_list_emptied(prop.nonpriority_claims)
 script: |
   <script>
     // docassemble's list collect DISABLES Continue when every row is deleted,

--- a/docassemble/BankruptcyClinic/data/questions/creditor-library-picker-test.yml
+++ b/docassemble/BankruptcyClinic/data/questions/creditor-library-picker-test.yml
@@ -1,6 +1,7 @@
 # Minimal standalone interview for testing the creditor library picker.
-# Provides the necessary dependencies (prop.nonpriority_claims) so the
-# picker can be tested without navigating the entire bankruptcy interview.
+# Provides the necessary dependencies (prop.nonpriority_claims,
+# prop.notice_only_parties) so the picker can be tested without navigating
+# the entire bankruptcy interview.
 ---
 modules:
   - .creditor_library
@@ -11,6 +12,12 @@ include:
 objects:
   - prop: DAObject
   - prop.nonpriority_claims: DAList
+  - prop.priority_claims: DAList
+  - prop.notice_only_parties: |
+      DAList.using(
+        object_type=DAObject,
+        complete_attribute='complete',
+        auto_gather=False)
 ---
 # Pre-configure the DAList to avoid triggering gather questions
 mandatory: True
@@ -38,4 +45,12 @@ subquestion: |
   % endfor
   % else:
   No creditors were selected.
+  % endif
+
+  % if defined('prop.notice_only_parties.gathered') and len(prop.notice_only_parties) > 0:
+  Notice-only parties (mailing matrix only):
+
+  % for c in prop.notice_only_parties:
+  - ${ c.name } (${ c.city }, ${ c.state })
+  % endfor
   % endif

--- a/docassemble/BankruptcyClinic/data/questions/creditor-library-picker.yml
+++ b/docassemble/BankruptcyClinic/data/questions/creditor-library-picker.yml
@@ -7,9 +7,10 @@
 #  Sets:
 #    - creditor_library_picker_done (True when the picker step is complete)
 #
-#  The picker pre-fills name/address into the relevant DAList so the
-#  user only has to fill the debt-specific details when the gather()
-#  questions appear.
+#  Two kinds of selection (Roxanne UAT follow-up, June 2026):
+#    - "owe money"  -> pre-fills a Schedule E/F claim (amounts asked later)
+#    - "notice only" -> prop.notice_only_parties, included in the creditor
+#       mailing matrix but NOT on the debt schedules
 # ──────────────────────────────────────────────
 ---
 # Seed the clinic's default common creditors (IRS, Nebraska Dept of Revenue)
@@ -26,20 +27,24 @@ question: |
   Common Creditors
 subquestion: |
   % if len(get_creditor_choices()) > 0:
-  Your clinic maintains a list of commonly seen creditors.
-  **Only select a creditor if you actually owe it money.** Each one you select
-  is added to your creditor schedules (Schedule E or F) with its name and
-  address pre-filled, and you will be asked for the amount you owe it.
+  Your clinic maintains a list of commonly seen creditors. There are two ways
+  to use it:
 
-  Selecting a creditor here is **not** needed just to send it a notice — leave
-  it unchecked if you don't owe it anything. You can always add more creditors
-  manually in the next steps.
+  * **Creditors you owe money to** are added to your creditor schedules
+    (Schedule E or F) with the name and address pre-filled — you will be asked
+    for the amount you owe.
+  * **Notice-only creditors** are added to the creditor mailing matrix so they
+    receive notice of your case, **without** creating a debt entry on your
+    schedules. Pick this for agencies you want notified but don't owe.
+
+  Leave a creditor unchecked in both lists if it has nothing to do with your
+  case. You can always add more creditors manually in the next steps.
   % else:
   No common creditors have been added to the library yet.
   Click **Continue** to enter your creditors manually.
   % endif
 fields:
-  - Select creditors to pre-fill: library_selected_ids
+  - Creditors you OWE money to: library_selected_ids
     datatype: checkboxes
     code: |
       [{c['value']: c['label']} for c in get_creditor_choices()]
@@ -47,6 +52,19 @@ fields:
     show if:
       code: |
         len(get_creditor_choices()) > 0
+  - Creditors to NOTIFY only (no debt owed): library_notice_only_ids
+    datatype: checkboxes
+    code: |
+      [{c['value']: c['label']} for c in get_creditor_choices()]
+    required: False
+    show if:
+      code: |
+        len(get_creditor_choices()) > 0
+validation code: |
+  if defined('library_selected_ids') and defined('library_notice_only_ids'):
+    _both = set(library_selected_ids.true_values()) & set(library_notice_only_ids.true_values())
+    if _both:
+      validation_error("You selected the same creditor in both lists. Pick one: either you owe it money (first list) or it should only receive a notice (second list).", field="library_notice_only_ids")
 continue button field: creditor_library_picker_done
 ---
 # Code block that runs after the picker to inject selected creditors
@@ -54,6 +72,13 @@ continue button field: creditor_library_picker_done
 # Secured creditors need too many additional fields to pre-fill usefully,
 # but nonpriority unsecured creditors share the same name/address structure.
 code: |
+  # Instantiate the target lists FIRST: referencing a not-yet-created
+  # objects-block list mid-run seeks its definition, which interrupts and
+  # re-runs this whole block — the idempotency guard then skips the
+  # already-appended creditors and the injected count comes out wrong.
+  prop.nonpriority_claims
+  prop.priority_claims
+  prop.notice_only_parties
   _all_records = get_all_creditors()
   _injected_count = 0
 
@@ -63,7 +88,7 @@ code: |
   # getattr-guarded: the standalone picker-test interview only declares
   # nonpriority_claims, so a raw prop.priority_claims read would seek forever.
   _already_present = set()
-  for _lst_name in ('priority_claims', 'nonpriority_claims'):
+  for _lst_name in ('priority_claims', 'nonpriority_claims', 'notice_only_parties'):
     _lst = getattr(prop, _lst_name, None)
     if _lst is None:
       continue
@@ -88,9 +113,16 @@ code: |
           # priority-type library creditor (IRS / NE DoR) fired the
           # "any PRIORITY unsecured debts?" gate right here, BEFORE secured
           # creditors (Roxanne, June 4), instead of in the 106EF section.
+          #
+          # NOTE: there_are_any is deliberately NOT set here. Forcing it True
+          # meant a filer who deleted every injected row was silently stuck on
+          # the claim screen (it demanded at least one claim with no way to
+          # say "none" — Roxanne UAT June 2026, reproduced empirically). With
+          # it unset, gather() proceeds off the appended elements, and if the
+          # filer deletes them all the Schedule E gate question is asked,
+          # where "No" moves on.
           _claim = prop.priority_claims.appendObject()
           _claim.type = _ctype
-          prop.priority_claims.there_are_any = True
         else:
           # Nonpriority claim (Schedule F)
           _claim = prop.nonpriority_claims.appendObject()  # no len(): see above
@@ -120,5 +152,31 @@ code: |
         _claim.who = 'Debtor 1 only'
         _claim.account_number = _data.get('account_suffix', '')
         _injected_count += 1
+
+  # Notice-only parties: mailing matrix entries with NO Schedule E/F claim
+  # (Roxanne UAT follow-up — she wanted IRS/NDR noticed without being forced
+  # to invent amounts owed). Indexed assignment so the static flow analyzer
+  # sees the definitions. prop.notice_only_parties is referenced directly —
+  # a getattr-with-default guard here returned None for the lazily-created
+  # objects-block list and silently skipped the injection; every interview
+  # that includes this file declares the list.
+  if defined('library_notice_only_ids'):
+    for _sel_id in library_notice_only_ids.true_values():
+      _rec_id = int(_sel_id)
+      if _rec_id in _all_records:
+        _data = _all_records[_rec_id]
+        if str(_data.get('name', '') or '').strip().upper() in _already_present:
+          continue
+        _np_k = len(prop.notice_only_parties.elements)
+        prop.notice_only_parties.appendObject()
+        prop.notice_only_parties[_np_k].name = _data['name']
+        prop.notice_only_parties[_np_k].street = _data.get('street', '')
+        prop.notice_only_parties[_np_k].city = _data.get('city', '')
+        prop.notice_only_parties[_np_k].state = state_name(_data.get('state', ''))
+        prop.notice_only_parties[_np_k].zip = _data.get('zip', '')
+        prop.notice_only_parties[_np_k].complete = True
+        _injected_count += 1
+    prop.notice_only_parties.gathered = True
+    prop.notice_only_parties.auto_gather = False
 
   creditor_library_injected = _injected_count

--- a/docassemble/BankruptcyClinic/data/questions/mailing-matrix.yml
+++ b/docassemble/BankruptcyClinic/data/questions/mailing-matrix.yml
@@ -82,6 +82,12 @@ code: |
       _add(_c.name, _c.street, _c.city, _c.state, _c.zip)
       _add_codebtor(_c)
 
+  # Notice-only parties from the creditor-library picker (Roxanne UAT
+  # follow-up): noticed via the matrix, no Schedule E/F claim.
+  if defined('prop.notice_only_parties.gathered') and prop.notice_only_parties.gathered:
+    for _c in prop.notice_only_parties:
+      _add(_c.name, _c.street, _c.city, _c.state, _c.zip)
+
   _matrix_text = '\n\n'.join(_entries)
 
   mailing_matrix_file = DAFile('mailing_matrix_file')

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -255,6 +255,14 @@ objects:
       DAList.using(
         object_type=DAObject,
         complete_attribute='complete')
+  # Notice-only parties (creditor matrix entries with no Schedule E/F claim) —
+  # populated exclusively by the creditor-library picker (Roxanne UAT
+  # follow-up, June 2026); never gathered interactively.
+  - prop.notice_only_parties: |
+      DAList.using(
+        object_type=DAObject,
+        complete_attribute='complete',
+        auto_gather=False)
   - prop.contracts_and_leases: |
       DAList.using(
         object_type=DAObject,
@@ -448,8 +456,11 @@ code: |
   prop.priority_claims.gather()
   # Skip the "do any creditors have nonpriority unsecured claims?" gate and go
   # straight to the list (clinic decision — virtually every filer has at least
-  # one ordinary unsecured debt).
-  prop.nonpriority_claims.there_are_any = True
+  # one ordinary unsecured debt). Conditional so the claim screen's "deleted
+  # every row = I have none" escape (106EF validation code) is not overwritten
+  # on the next mandatory re-pass (Roxanne UAT follow-up, June 2026).
+  if not defined('prop.nonpriority_claims.there_are_any'):
+    prop.nonpriority_claims.there_are_any = True
   prop.nonpriority_claims.gather()
   prop.contracts_and_leases.gather()
   codebtor_auto_populated

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -156,6 +156,18 @@ _STATE_TO_ABBR = {
     'wisconsin': 'WI', 'wyoming': 'WY', 'district of columbia': 'DC',
 }
 
+def mark_list_emptied(the_list):
+    """Record that the filer deleted every row on a list-collect screen — an
+    explicit "I have none" (Roxanne UAT follow-up, June 2026). Done through a
+    function on purpose: assigning `the_list.there_are_any` / `.gathered`
+    directly inside a question's `validation code` registers that list-collect
+    question as a DEFINER of those variables, so an empty-list gather seek
+    asks the collect screen without an index ("list collect question needs
+    iterator i" crash) instead of the yesno gate question."""
+    the_list.there_are_any = False
+    the_list.gathered = True
+
+
 def state_abbr(value):
     """Return the 2-letter abbreviation for a state name; pass through if already
     an abbreviation or unrecognized. Used to keep court-form PDF fields in the

--- a/scripts/test-completeness-baseline.txt
+++ b/scripts/test-completeness-baseline.txt
@@ -1,4 +1,5 @@
 creditor-library.spec.ts
+creditor-picker-delete-all.spec.ts
 cross-validation-demo.spec.ts
 cross-validation.spec.ts
 data-validation.spec.ts

--- a/tests/creditor-library.spec.ts
+++ b/tests/creditor-library.spec.ts
@@ -459,6 +459,40 @@ test.describe('Creditor Library – Picker', () => {
 
     await screenshot(page, 'picker-after-selection');
   });
+
+  test('Notice-only selection goes to the matrix list, not the claims', async ({ page }) => {
+    // Roxanne UAT follow-up (June 2026): selecting a creditor in the
+    // "NOTIFY only" list adds it to prop.notice_only_parties (creditor
+    // mailing matrix) without creating a Schedule E/F claim.
+    await gotoAdmin(page);
+    const body0 = await page.locator('body').textContent();
+    if (!body0?.includes(TEST_CREDITOR.name)) {
+      await addCreditorViaAdmin(page, TEST_CREDITOR);
+    }
+
+    await page.goto(PICKER_TEST_URL + '&new_session=1');
+    await waitForDaPageLoad(page);
+
+    // Check the first option of the notice-only group via a real label click
+    // (skipping the auto-added "None of the above").
+    const noticeGroup = `[data-varname="${b64('library_notice_only_ids')}"]`;
+    const label = page.locator(`${noticeGroup} label.danon-nota-checkbox[role="checkbox"]`).first();
+    await expect(label).toBeVisible();
+    await label.click();
+    await page.waitForTimeout(300);
+
+    await clickContinue(page);
+    await waitForDaPageLoad(page);
+
+    const heading = await page.locator('h1, h2, h3').first().textContent();
+    expect(heading?.trim()).toBe('Picker Test Complete');
+    const resultBody = await page.locator('body').textContent();
+    expect(resultBody).toContain('Injected 1 creditor');
+    expect(resultBody).toContain('Notice-only parties (mailing matrix only):');
+    // No claim was created
+    expect(resultBody).toContain('No creditors were selected.');
+    console.log('[PICKER] ✅ Notice-only creditor recorded without a claim');
+  });
 });
 
 

--- a/tests/creditor-picker-delete-all.spec.ts
+++ b/tests/creditor-picker-delete-all.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression (Roxanne UAT follow-up, June 2026): after the picker injects
+ * IRS / NE Dept of Revenue into the priority claims list, the filer can
+ * DELETE BOTH rows and continue past Schedule E without being forced to
+ * invent amounts.
+ *
+ * Empirical notes from the diagnosis this spec grew out of:
+ *  - list-collect Delete hides the row + disables its inputs client-side (no
+ *    form submit), so other rows' required fields can NOT block deletion;
+ *  - the dead end was the injection force-setting there_are_any=True: with
+ *    every row deleted, Continue silently re-rendered the same screen
+ *    demanding a claim. The fix leaves there_are_any unset so deleting all
+ *    rows re-asks the Schedule E gate, where "No" proceeds.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { waitForDaPageLoad, clickContinue, b64 } from './helpers';
+import {
+  navigateToDebtorPage, fillDebtorAndAdvance, passDebtorFinal,
+} from './navigation-helpers';
+
+async function getHeading(p: import('@playwright/test').Page) {
+  return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
+}
+
+test.setTimeout(420_000);
+
+test('delete BOTH injected priority claims, then Continue', async ({ page }) => {
+  await navigateToDebtorPage(page, SIMPLE_SINGLE);
+  await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
+  await passDebtorFinal(page);
+
+  let pickedCreditors = false;
+
+  // Generic masked advance (same approach as probe-nonpriority-claim) until
+  // the priority claim detail screen, selecting IRS + NDR on the picker.
+  for (let i = 0; i < 80; i++) {
+    // Settle BEFORE reading the heading: heading reads and clicks must not
+    // straddle docassemble's ajax page swap (a click that lands on the NEXT
+    // page silently answers it — this masqueraded as a "picker auto-advance"
+    // product bug during diagnosis).
+    await waitForDaPageLoad(page);
+    const h = await getHeading(page);
+    console.log(`[probe] step ${i}: "${h}"`);
+    if (/about a priority unsecured claim/i.test(h)) break;
+    if (/about a nonpriority unsecured claim/i.test(h)) {
+      throw new Error('overshot to the nonpriority screen — picker selection did not inject priority claims');
+    }
+
+    if (/common creditors/i.test(h)) {
+      // Skip the auto-added "None of the above" option — clicking it unchecks
+      // the real selections (labelauty nota behavior). Target ONLY the
+      // owe-money list: the picker now has a second, notice-only checkbox
+      // group, and selecting a creditor in both lists is a validation error.
+      const oweGroup = `[data-varname="${b64('library_selected_ids')}"]`;
+      const optLabels = page.locator(`${oweGroup} label.danon-nota-checkbox[role="checkbox"]`);
+      const labelCount = await optLabels.count();
+      await waitForDaPageLoad(page);
+      for (let k = 0; k < labelCount; k++) {
+        const lab = optLabels.nth(k);
+        if (await lab.isVisible().catch(() => false)) {
+          await lab.click();
+          await page.waitForTimeout(250);
+        }
+      }
+      const checkedCount = await page.evaluate(() =>
+        document.querySelectorAll('input[type="checkbox"]:checked').length);
+      console.log(`[probe] picker labels=${labelCount} checked-after-click=${checkedCount}`);
+      pickedCreditors = checkedCount > 0;
+      await page.locator('#da-continue-button').click({ timeout: 10000 }).catch(() => {});
+      await page.waitForLoadState('networkidle').catch(() => {});
+      continue;
+    }
+
+    const hasContinue = (await page.locator('#da-continue-button').count()) > 0;
+    if (!hasContinue) {
+      // yes/no button page: prefer No to skip optional sections
+      const noBtn = page.locator('button.btn-da:visible').filter({ hasText: /^\s*No\s*$/ }).first();
+      if ((await noBtn.count()) > 0) {
+        await noBtn.click({ timeout: 10000 }).catch(() => {});
+      } else {
+        await page.locator('button.btn-da[value="False"]:visible').first().click({ timeout: 10000 }).catch(() => {});
+      }
+      await page.waitForLoadState('networkidle').catch(() => {});
+      continue;
+    }
+    // Fill visible required-ish inputs with safe defaults and continue
+    await page.evaluate(() => {
+      const seen = new Set<string>();
+      document.querySelectorAll('input[type="radio"]').forEach((r) => {
+        const radio = r as HTMLInputElement;
+        if (!radio.name || seen.has(radio.name)) return;
+        seen.add(radio.name);
+        const group = Array.from(document.querySelectorAll(
+          `input[type="radio"][name="${CSS.escape(radio.name)}"]`)) as HTMLInputElement[];
+        if (group.some((g) => g.checked)) return;
+        const visible = group.filter((g) => {
+          const lab = g.id && document.querySelector(`label[for="${CSS.escape(g.id)}"]`) as HTMLElement | null;
+          return !!lab && (lab as HTMLElement).offsetParent !== null;
+        });
+        if (!visible.length) return;
+        const no = visible.find((g) => g.value === 'False') ?? visible[visible.length - 1];
+        const lab = document.querySelector(`label[for="${CSS.escape(no.id)}"]`) as HTMLElement;
+        lab.click();
+      });
+      document.querySelectorAll('input[type="text"], input[type="number"], input[type="date"], textarea').forEach((el) => {
+        const input = el as HTMLInputElement;
+        if (input.offsetParent === null || input.value) return;
+        const grp = input.closest('.input-group');
+        const isCurrency = !!(grp && /[$]/.test(grp.textContent || ''));
+        if (input.type === 'date') input.value = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+        else if (isCurrency || input.type === 'number') input.value = '0';
+        else input.value = 'N/A';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      document.querySelectorAll('select').forEach((el) => {
+        const sel = el as HTMLSelectElement;
+        if (sel.offsetParent === null || sel.value) return;
+        for (const o of Array.from(sel.options)) {
+          if (o.value) { sel.value = o.value; break; }
+        }
+        sel.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    });
+    await page.locator('#da-continue-button').click({ timeout: 10000 }).catch(() => {});
+    await page.waitForLoadState('networkidle').catch(() => {});
+  }
+
+  expect(pickedCreditors, 'reached and used the Common Creditors picker').toBe(true);
+  const heading = await getHeading(page);
+  expect(heading, 'reached the priority claim screen').toMatch(/about a priority unsecured claim/i);
+
+  // Both injected rows render with their names prefilled (input VALUES —
+  // innerText doesn't include them)
+  const inputValues = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('input')).map((i) => (i as HTMLInputElement).value).join('|'));
+  expect(inputValues).toContain('Internal Revenue Service');
+  expect(inputValues).toContain('Nebraska Department of Revenue');
+
+  // Delete EVERY row (click visible delete buttons until none remain)
+  for (let i = 0; i < 6; i++) {
+    const del = page.locator('button.dacollectremove:visible, button.dacollectremoveexisting:visible').first();
+    if ((await del.count()) === 0) break;
+    await del.click();
+    await page.waitForTimeout(400);
+  }
+  const remainingDeletes = await page
+    .locator('button.dacollectremove:visible, button.dacollectremoveexisting:visible').count();
+  console.log(`[probe] visible delete buttons remaining: ${remainingDeletes}`);
+
+  // Continue — deleting every row is an explicit "I have none": the flow
+  // must move on to Schedule F (this used to silently re-render the claim
+  // screen, demanding amounts for creditors the filer just deleted).
+  await clickContinue(page);
+  // Settle: a concurrent ajax racing the submit makes the submit stale and
+  // silently discarded (empirically observed during diagnosis).
+  await page.waitForTimeout(1500);
+  await waitForDaPageLoad(page);
+  const afterHeading = await getHeading(page);
+  console.log(`[probe] after deleting all + Continue: "${afterHeading}"`);
+  expect(afterHeading, 'flow continues past Schedule E with zero claims')
+    .toMatch(/about a nonpriority unsecured claim/i);
+});

--- a/tests/roxanne-uat-2026-06.spec.ts
+++ b/tests/roxanne-uat-2026-06.spec.ts
@@ -98,10 +98,17 @@ test.describe('Roxanne UAT June 2026 — static wiring', () => {
     expect(y).toMatch(/priority_unsecured_claim_details[\s\S]{0,400}Schedule E/);
   });
 
-  test('creditor picker: owe-money wording and idempotent injection', async ({ page: _ }) => {
+  test('creditor picker: owe vs notice-only lists, idempotent injection, no forced there_are_any', async ({ page: _ }) => {
     const y = read('creditor-library-picker.yml');
-    expect(y, 'picker explains selections become claims').toContain('Only select a creditor if you actually owe it money.');
+    expect(y, 'owe-money list').toContain('Creditors you OWE money to: library_selected_ids');
+    expect(y, 'notice-only list').toContain('Creditors to NOTIFY only (no debt owed): library_notice_only_ids');
+    expect(y, 'same creditor in both lists rejected').toContain('You selected the same creditor in both lists');
     expect(y, 'injection skips creditors already present').toContain('_already_present');
+    // The delete-all dead end: injection must NOT force there_are_any=True
+    expect(y).not.toContain('prop.priority_claims.there_are_any = True');
+    // Notice-only parties feed the mailing matrix
+    const matrix = read('mailing-matrix.yml');
+    expect(matrix).toContain('prop.notice_only_parties');
   });
 
   test('creditor matrix: conclusion page has a real download link', async ({ page: _ }) => {


### PR DESCRIPTION
Follow-ups from Roxanne's June UAT batch (per Alex: build the notice-only feature she expected, and actually fix — not mitigate — the can't-delete/can't-move-on trap).

## 1. Notice-only creditors (new feature)

The Common Creditors picker now has **two lists**:

* **Creditors you OWE money to** — pre-fills a Schedule E/F claim (as before; you're asked the amount later)
* **Creditors to NOTIFY only (no debt owed)** — goes to a new `prop.notice_only_parties` list that feeds the **creditor mailing matrix** with **no entry on the debt schedules**

This is exactly what Roxanne thought she was doing when she selected IRS/NDR "for notices" — and why her 106E ended up listing debts she didn't owe. Selecting the same creditor in both lists is a validation error.

## 2. The "Software will NOT let me move on" trap — diagnosed and fixed

I reproduced her flow empirically (new regression spec drives the real path: picker → inject IRS/NDR → Schedule E). Findings worth recording:

* **Deleting rows was never blocked by other rows' required fields** — list-collect Delete hides the row and disables its inputs client-side; no validation runs on the click. My earlier "mitigated, not fixed" framing was wrong about the mechanism.
* The real traps were: (a) docassemble **disables Continue** once every row is deleted — a silent dead end; and (b) `there_are_any` latches True (set by the picker injection, and by `gather()` itself), so even a successful empty submission re-demanded a claim.

Fix, in three coordinated parts (applied to **both** the Schedule E and Schedule F screens):

* the picker injection no longer force-sets `there_are_any`
* the claim screens re-enable Continue when every row is deleted (a small poll — the core delete handlers stop event propagation, so delegation can't work)
* `validation code` records an emptied list as "I have none" via a new `mark_list_emptied()` helper, so the flow proceeds to the next schedule. Schedule F's *"if you have none to add, you can continue past this section"* promise now actually works; the mandatory block's F gate-skip is conditional so the escape isn't overwritten.

**Why the helper function matters** (cost me 103 suite crashes to learn): assigning `there_are_any` directly inside a list-collect question's `validation code` registers that question as a *definer* of the gate variable — an empty-list gather seek then asks the collect screen without an index (`DAException: list collect question needs iterator i`). Routing the assignment through an opaque function keeps the yesno gate as the only askable definer.

* Injection robustness: the three target lists are instantiated before any appends — a mid-block seek re-ran the block and the idempotency guard then under-counted.

## Verification

- Full Playwright suite on the 5-container pool: **153 passed / 0 failed** (includes the two new runtime regressions); strict-validator walker reports **zero silently-blocking pages**
- New `tests/creditor-picker-delete-all.spec.ts`: main interview, inject IRS + NDR → delete both → Continue proceeds to Schedule F with zero claims
- New notice-only test in `tests/creditor-library.spec.ts`: notify-only selection records a matrix party and **no** claim
- All static gates clean (flow-gaps, yaml-ids, caps-sync, pdf-fields, test-completeness)

## Note for Roxanne

With this PR her original scenario becomes: pick IRS/NDR in the **notify-only** list → they appear on the creditor matrix, nothing on Schedule E, no amounts demanded. If she does owe one of them, the owe list still pre-fills the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)