### PR TITLE
SD life insurance exemption: $20,000 per SDCL 58-12-4 (William/ERLS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ Every hit is a real user stuck. A daily 06:00 cron on Alex's machine runs it
 dollar caps in `objects.py get_exemption_limits()` against
 `data/static/exemptions.js` and fails on NEW divergence
 (`scripts/caps-sync-baseline.txt` holds known mismatches awaiting attorney
-verification — currently SD life_insurance and SD retirement).
+verification — currently SD retirement; SD life_insurance resolved to $20,000
+per SDCL 58-12-4, William Franck/ERLS June 2026).
 
 ## Testing
 

--- a/docassemble/BankruptcyClinic/data/static/exemptions.js
+++ b/docassemble/BankruptcyClinic/data/static/exemptions.js
@@ -47,7 +47,7 @@ const southDakotaExemptions = {
   retirement: { law: 'retirement (SDCL 43-45-26)', limit: 1000000, amount: 0 },
   public_assistance: { law: 'public assistance (SDCL 28-7-16)', limit: 0, amount: 0 },
   wages: { law: 'Wages (SDCL 15-20-12)', limit: 0, amount: 0 },
-  life_insurance: { law: 'Life insurance proceeds (SDCL 58-12-4. 43-45-6)', limit: 10000, amount: 0 },
+  life_insurance: { law: 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)', limit: 20000, amount: 0 }, // SDCL 58-12-4 beneficiary proceeds, $20,000 (William Franck, ERLS, June 2026)
   workers_comp: { law: 'Workers Compensation (SDCL 62-4-42)', limit: 0, amount: 0 },
   unemployment: { law: 'Unemployment (SDCL 61-6-28)', limit: 0, amount: 0 },
   student_loan: { law: 'Student Loan (20 U.S.C. § 1095a(d))', limit: 0, amount: 0 },

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -15,7 +15,7 @@ SOUTH_DAKOTA_EXEMPTIONS = {
     'retirement': 'Retirement (SDCL 43-45-26)',
     'public_assistance': 'Public assistance (SDCL 28-7-16)',
     'wages': 'Wages (SDCL 15-20-12)',
-    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4. 43-45-6)',
+    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)',
     'workers_comp': 'Workers compensation (SDCL 62-4-42)',
     'unemployment': 'Unemployment (SDCL 61-6-28)',
     'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
@@ -331,7 +331,10 @@ def get_exemption_limits(user_state):
             'tools': 0,              # Unlimited
             'retirement': 0,          # Unlimited
             'wages': 0,              # Unlimited (follow federal garnishment rules)
-            'life_insurance': 0,      # Unlimited
+            'life_insurance': 20000,  # SDCL 58-12-4: proceeds payable to the
+                                      # beneficiary, $20,000 (William Franck,
+                                      # ERLS, June 2026). 43-45-6 ($10,000) is
+                                      # the narrower estate-distribution case.
             'workers_comp': 0,        # Unlimited
             'unemployment': 0,        # Unlimited
             'social_security': 0,     # Unlimited

--- a/scripts/caps-sync-baseline.txt
+++ b/scripts/caps-sync-baseline.txt
@@ -1,2 +1,1 @@
-South Dakota	life_insurance	py=0	js=10000
 South Dakota	retirement	py=0	js=1000000


### PR DESCRIPTION
## What

William Franck (ERLS) verified the South Dakota life-insurance and retirement statutes that were sitting in `caps-sync-baseline.txt` awaiting attorney sign-off. This PR encodes the **life insurance** result; the retirement value is left as-is pending a follow-up to William.

**Life insurance** — SDCL 58-12-4 exempts proceeds payable to the beneficiary up to **$20,000** (43-45-6's $10,000 is the narrower estate-distribution case). The app's `life_insurance` category is the debtor's own policy, so it now enforces $20,000 instead of treating it as unlimited.

## Changes
- **`objects.py`** — SD `life_insurance` `0` (unlimited) → `20000`; law-string punctuation fix (`58-12-4. 43-45-6` → `58-12-4, 43-45-6`).
- **`exemptions.js`** — SD `life_insurance` limit `10000` → `20000` + matching law-string fix, so the live per-screen tracker and `objects.py` agree.
- **`caps-sync-baseline.txt`** — drop the now-synced `life_insurance` line. `npm run lint:caps-sync` passes with only SD `retirement` baselined.
- **`CLAUDE.md`** — caps-sync note updated.

## Still open (not in this PR)
SD **retirement** (private IRA/401k category) stays baselined. William confirmed the cited `SDCL 43-45-26` doesn't exist but supplied only public-pension cites (9-16-47, 3-12C-216) that are already separate unlimited categories — no private-retirement cap. Follow-up email to William drafted; will encode once he confirms the citation/cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)