### PR TITLE
SD private retirement exemption: $1,000,000 per SDCL 43-45-16 (William/ERLS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,9 @@ Every hit is a real user stuck. A daily 06:00 cron on Alex's machine runs it
 dollar caps in `objects.py get_exemption_limits()` against
 `data/static/exemptions.js` and fails on NEW divergence
 (`scripts/caps-sync-baseline.txt` holds known mismatches awaiting attorney
-verification — currently SD retirement; SD life_insurance resolved to $20,000
-per SDCL 58-12-4, William Franck/ERLS June 2026).
+verification — currently EMPTY: all SD caps confirmed by William Franck/ERLS
+June 2026 — life_insurance $20,000 (SDCL 58-12-4), retirement $1,000,000
+(SDCL 43-45-16)).
 
 ## Testing
 

--- a/docassemble/BankruptcyClinic/data/static/exemptions.js
+++ b/docassemble/BankruptcyClinic/data/static/exemptions.js
@@ -44,7 +44,7 @@ const southDakotaExemptions = {
   health_aids: { law: 'Health Aids (SDCL 43-45-2)', limit: 0, amount: 0 },
   city_employee_pensions: { law: 'city employee pensions (SDCL 9-16-47)', limit: 0, amount: 0 },
   public_employee_pensions: { law: 'public employee pensions (SDCL 3-12-115)', limit: 0, amount: 0 },
-  retirement: { law: 'retirement (SDCL 43-45-26)', limit: 1000000, amount: 0 },
+  retirement: { law: 'retirement (SDCL 43-45-16)', limit: 1000000, amount: 0 }, // $1M cap on employee benefit plans (William Franck, ERLS, June 2026)
   public_assistance: { law: 'public assistance (SDCL 28-7-16)', limit: 0, amount: 0 },
   wages: { law: 'Wages (SDCL 15-20-12)', limit: 0, amount: 0 },
   life_insurance: { law: 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)', limit: 20000, amount: 0 }, // SDCL 58-12-4 beneficiary proceeds, $20,000 (William Franck, ERLS, June 2026)

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -12,7 +12,7 @@ SOUTH_DAKOTA_EXEMPTIONS = {
     'tools': 'Tools of the trade (SDCL 43-45-5(6))',
     'city_employee_pensions': 'City employee pensions (SDCL 9-16-47)',
     'public_employee_pensions': 'Public employee pensions (SDCL 3-12-115)',
-    'retirement': 'Retirement (SDCL 43-45-26)',
+    'retirement': 'Retirement (SDCL 43-45-16)',
     'public_assistance': 'Public assistance (SDCL 28-7-16)',
     'wages': 'Wages (SDCL 15-20-12)',
     'life_insurance': 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)',
@@ -329,7 +329,10 @@ def get_exemption_limits(user_state):
             'personal_property': 0,   # Unlimited
             'health_aids': 0,         # Unlimited
             'tools': 0,              # Unlimited
-            'retirement': 0,          # Unlimited
+            'retirement': 1000000,    # SDCL 43-45-16: $1,000,000 cap on
+                                      # employee benefit plans (William Franck,
+                                      # ERLS, June 2026). Prior cite 43-45-26
+                                      # does not exist.
             'wages': 0,              # Unlimited (follow federal garnishment rules)
             'life_insurance': 20000,  # SDCL 58-12-4: proceeds payable to the
                                       # beneficiary, $20,000 (William Franck,

--- a/scripts/caps-sync-baseline.txt
+++ b/scripts/caps-sync-baseline.txt
@@ -1,1 +1,0 @@
-South Dakota	retirement	py=0	js=1000000


### PR DESCRIPTION
## What
William Franck (ERLS) confirmed the last open SD exemption value. The private-retirement (IRA/401k) category is **SDCL 43-45-16**, which caps employee-benefit-plan exemptions at **$1,000,000**. The app previously cited the nonexistent SDCL 43-45-26 and enforced no cap.

## Changes
- **`objects.py`** — SD `retirement` `0` (unlimited) → `1000000`; citation `43-45-26` → `43-45-16`.
- **`exemptions.js`** — citation `43-45-26` → `43-45-16` (limit already `1000000`, now synced).
- **`caps-sync-baseline.txt`** — now **empty**: every SD exemption cap is attorney-confirmed and the py/js sources agree. `npm run lint:caps-sync` passes clean.

## Context
Closes the SD-exemption verification thread (June 2026): life insurance ($20,000, SDCL 58-12-4 — PR #124) and now retirement ($1,000,000, SDCL 43-45-16). All values verified by William Franck, ERLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)