### PR TITLE
Means test: include non-filing spouse income in the median comparison

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
@@ -119,11 +119,24 @@ fields:
 id: debtor2_current_monthly_income
 section: form_122a
 question: |
+  % if len(debtor) > 1:
   Calculate Debtor 2 current monthly income
+  % else:
+  Calculate your spouse's current monthly income
+  % endif
 subquestion: |
+  % if len(debtor) > 1:
   Be as complete and accurate as possible. If two married people are filing together, both are equally responsible for being accurate.
+  % else:
+  Your spouse is not filing with you, but because you live in the same household their income still counts toward the means test. Enter your spouse's income below.
+  % endif
 fields:
-  - note: Income calculation Debtor 2
+  - note: |
+      % if len(debtor) > 1:
+      Income calculation Debtor 2
+      % else:
+      Income calculation — your spouse
+      % endif
   - Your gross wages, salary, tips, bonuses, overtime, and commissions: monthly_income.gross_wages2
     datatype: currency
     default: ${ (getattr(debtor[1].income, 'income_amount_1', 0) + getattr(debtor[1].income, 'overtime_pay_1', 0)) if len(debtor) > 1 else 0 }
@@ -225,7 +238,14 @@ code: |
                            _n(monthly_income, 'rental_operating_expenses1')
                           )
   debtor_2_income = 0
-  if len(debtor) > 1:
+  # Column-B income belongs in CMI for a filing spouse (len(debtor) > 1) AND for
+  # a non-filing spouse who is not legally separated / living apart
+  # (11 U.S.C. 101(10A)(B)(i); William Franck, ERLS, June 2026). In both cases
+  # the spouse income lives in the 'gross_wages2'... fields.
+  _include_spouse = len(debtor) > 1 or (
+      monthly_income.filing_status == "Married and your spouse is NOT filing with you."
+      and getattr(monthly_income, 'separated_status', '') != 'Living separately or are legally separated')
+  if _include_spouse:
     debtor_2_income = (_n(monthly_income, 'gross_wages2') +
                             _n(monthly_income, 'alimony2') +
                             _n(monthly_income, 'other_income2') +

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -844,13 +844,18 @@ code: |
   if monthly_income.non_consumer_debts == False and monthly_income.disabled_veteran == False and monthly_income.reservists == False:
     monthly_income.filing_status
     monthly_income.gross_wages1
-    if monthly_income.filing_status == "Married and your spouse is filing with you.":
+    # A non-filing spouse's income is part of current monthly income for the
+    # median test UNLESS the spouses are legally separated / living apart
+    # (11 U.S.C. 101(10A)(B)(i); confirmed William Franck, ERLS, June 2026). So
+    # collect the Column-B / spouse income screen for BOTH a filing spouse and a
+    # non-filing-but-not-separated spouse.
+    if monthly_income.filing_status == "Married and your spouse is filing with you." or (monthly_income.filing_status == "Married and your spouse is NOT filing with you." and getattr(monthly_income, 'separated_status', '') != 'Living separately or are legally separated'):
       monthly_income.gross_wages2
     else:
-      # Single / spouse-not-filing: the debtor-2 income screen is never shown, so
-      # the 122A PDF would read undefined debtor-2 fields and crash for ANY
-      # non-married-filing consumer-debt filer. Default every debtor-2 field the
-      # form reads (currency -> 0, source labels -> '').
+      # Single / legally-separated spouse: the debtor-2 income screen is never
+      # shown, so the 122A PDF would read undefined debtor-2 fields and crash for
+      # ANY such consumer-debt filer. Default every debtor-2 field the form reads
+      # (currency -> 0, source labels -> '').
       for _f2 in ['gross_wages2', 'alimony2', 'other_income2', 'business_gross_receipts2',
                   'business_operating_expenses2', 'rental_gross_receipts2',
                   'rental_operating_expenses2', 'interest2', 'unemployment2',

--- a/tests/means-test-nonfiling-spouse.spec.ts
+++ b/tests/means-test-nonfiling-spouse.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Substantive-law regression: a NON-FILING spouse's income is INCLUDED in
+ * current monthly income for the means-test median comparison when the spouses
+ * are not legally separated (11 U.S.C. 101(10A)(B)(i); confirmed William Franck,
+ * ERLS, June 2026).
+ *
+ * Discriminating scenario: a Nebraska debtor filing ALONE, married, spouse NOT
+ * filing, living in the same household. Debtor wages $2,800/mo (below the NE
+ * household-of-1 median ~$5,441); non-filing spouse wages $4,000/mo. Combined
+ * CMI $6,800 is ABOVE median. If the spouse income were (wrongly) excluded, the
+ * debtor alone would be below median.
+ *
+ * The test enters the spouse's income on the Column-B screen and asserts the
+ * review screen's estimated overall income is $6,800 (spouse included), never
+ * $2,800 (spouse excluded), then finishes to PDF assembly.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  walkToMeansTestStart,
+  navigateCaseDetails,
+  navigateBusiness,
+  navigateHazardousProperty,
+  navigateCreditCounseling,
+  navigateDynamicPhase,
+} from './navigation-helpers';
+import {
+  b64,
+  waitForDaPageLoad,
+  selectByName,
+  selectYesNoRadio,
+  fillByName,
+  clickContinue,
+  clickNthByName,
+} from './helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+test.setTimeout(420_000);
+
+test('non-filing spouse income is included in the means-test median comparison', async ({ page }) => {
+  await walkToMeansTestStart(page, { ...SIMPLE_SINGLE, name: 'nonfiling-spouse-cmi' });
+
+  // means_test_presumption_of_abuse
+  await selectByName(page, b64('monthly_income.means_type'), 'There is no presumption of abuse.');
+  await clickContinue(page);
+
+  // means_test_exemptions — consumer debts → full median comparison.
+  await waitForDaPageLoad(page);
+  await selectYesNoRadio(page, 'monthly_income.non_consumer_debts', false);
+  await page.waitForTimeout(300);
+  await selectYesNoRadio(page, 'monthly_income.disabled_veteran', false);
+  await page.waitForTimeout(300);
+  await selectYesNoRadio(page, 'monthly_income.reservists', false);
+  await page.waitForTimeout(300);
+  await clickContinue(page);
+
+  // household_and_dependents_info — married, spouse NOT filing, same household.
+  await waitForDaPageLoad(page);
+  await selectByName(page, b64('monthly_income.filing_status'), 'Married and your spouse is NOT filing with you.');
+  await page.waitForTimeout(300);
+  await page.getByRole('combobox', { name: /You and your spouse are/i })
+    .selectOption('Living in the same household and not legally separated.');
+  await page.waitForTimeout(300);
+  await clickContinue(page);
+
+  // debtor1_current_monthly_income — defaults from Schedule I ($2,800 wages).
+  await waitForDaPageLoad(page);
+  await clickContinue(page);
+
+  // spouse (Column B) income screen — now shown for a non-filing, not-separated
+  // spouse. Enter $4,000/mo wages.
+  await waitForDaPageLoad(page);
+  const heading = ((await page.locator('h1').first().textContent()) || '').toLowerCase();
+  expect(heading).toContain("spouse");
+  await fillByName(page, b64('monthly_income.gross_wages2'), '4000');
+  await clickContinue(page);
+
+  // Median family income screen.
+  await waitForDaPageLoad(page);
+  await clickContinue(page);
+
+  // review_122 — assert on the computed figure (the dev-mode source panel dumps
+  // both template branches, so assert numbers, not prose). $6,800 proves the
+  // spouse's $4,000 was included; $2,800 would mean it was wrongly excluded.
+  await waitForDaPageLoad(page);
+  const body = ((await page.locator('body').textContent()) || '').toLowerCase();
+  expect(body).toContain('$6,800.00');
+  expect(body).not.toContain('$2,800.00');
+
+  await clickNthByName(page, b64('monthly_income.reviewed'), 0);
+  await waitForDaPageLoad(page);
+  await navigateCaseDetails(page);
+  await navigateBusiness(page);
+  await navigateHazardousProperty(page);
+  await navigateCreditCounseling(page, { ...SIMPLE_SINGLE, name: 'nonfiling-spouse-cmi' });
+  await navigateDynamicPhase(page, { ...SIMPLE_SINGLE, name: 'nonfiling-spouse-cmi' });
+
+  await finishAndAssertAllPdfs(page);
+});

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -1102,8 +1102,12 @@ export async function navigateMeansTest(page: Page, opts: MeansTestOptions = {})
   await waitForDaPageLoad(page);
   await clickContinue(page);
 
-  // debtor2_current_monthly_income — only for married-filing-jointly.
-  if (filingIdx === 1) {
+  // debtor2_current_monthly_income — shown for married-filing-jointly AND for a
+  // non-filing spouse who is NOT legally separated (their income counts toward
+  // the means test, 11 U.S.C. 101(10A)(B)(i)). Accept the defaults here; tests
+  // that need a specific spouse income drive this screen themselves.
+  const spouseIncomeShown = filingIdx === 1 || (filingIdx === 2 && (opts.separatedStatusIndex ?? 0) === 0);
+  if (spouseIncomeShown) {
     await waitForDaPageLoad(page);
     await clickContinue(page);
   }


### PR DESCRIPTION
## What
A **non-filing spouse's income** is part of current monthly income for the median test unless the spouses are legally separated / living apart — 11 U.S.C. § 101(10A)(B)(i), confirmed by William Franck (ERLS, June 2026).

Previously the Column-B / spouse income screen was shown **only for joint filings**, so a debtor filing alone with a non-filing spouse had the spouse's income defaulted to `$0` and omitted from CMI — understating income for the median test.

## Changes
- **`voluntary-petition.yml`** — seek the spouse income screen for a non-filing, *not-legally-separated* spouse as well as a filing spouse. Single / legally-separated still default the debtor-2 fields to 0.
- **`122A-question-blocks.yml`** — include the `gross_wages2…` (Column B) fields in the review-screen `overall_means_income` for that case (the PDF builder's `_cmi2` already reads them unconditionally, so the screen and the form now agree). The spouse income screen's heading/subquestion now read "your spouse" when the spouse is not a co-filer.
- **`navigation-helpers.ts`** — `navigateMeansTest` advances through the spouse income screen for the married-not-filing-same-household path too.
- **`tests/means-test-nonfiling-spouse.spec.ts`** — NE debtor filing alone, spouse not filing, same household; debtor $2,800/mo + spouse $4,000/mo. Asserts the review screen overall income is **$6,800 (spouse included)**, never $2,800, and runs through to PDF assembly.

## Verification
- New spec passes end-to-end to PDF (deployed to `datest`).
- Regression: SS-exclusion spec, consumer-debt means-test probe, and the SD joint-couple scenario all still pass; `npm run lint` green.

Part of the William/ERLS June 2026 substantive-law batch (item D of 7). Note the separation handling pairs with the existing `separated_status` question, which already drives the form's marital-status checkboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)