### PR TITLE
Prior-bankruptcy: warn when a discharge may be barred (727(a)(8)/(9))

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -520,8 +520,16 @@ allowed to set:
 fields:
   - District: case.previous_bankruptcy[i].district
     code: courts_list
-  - When: case.previous_bankruptcy[i].when
+  - Chapter: case.previous_bankruptcy[i].chapter
+    choices:
+      - "7"
+      - "11"
+      - "12"
+      - "13"
+  - When was this case filed?: case.previous_bankruptcy[i].when
     datatype: date
+  - Was a discharge granted in this case?: case.previous_bankruptcy[i].discharge_granted
+    datatype: yesnoradio
   - Case Number: case.previous_bankruptcy[i].case_number
 section: case_det
 list collect: True
@@ -533,6 +541,45 @@ under: |
   ${ previous_bankruptcy_table }
 yesno: case.previous_bankruptcy.there_is_another
 section: case_det
+---
+# Discharge-eligibility check (11 U.S.C. 727(a)(8)/(9)). The bar runs from the
+# prior case's FILING date, not the discharge date (William Franck, ERLS,
+# June 2026): a prior Chapter 7 discharge in a case filed within 8 years, or a
+# prior Chapter 12/13 discharge in a case filed within 6 years, before this
+# petition bars a discharge here. Only a GRANTED discharge triggers the bar.
+code: |
+  _risk = False
+  if getattr(case.previous_bankruptcy, 'gathered', False):
+    for _pb in case.previous_bankruptcy:
+      if not getattr(_pb, 'discharge_granted', False):
+        continue
+      _filed = getattr(_pb, 'when', None)
+      if not _filed:
+        continue
+      _yrs = date_difference(starting=_filed, ending=today()).years
+      _ch = str(getattr(_pb, 'chapter', ''))
+      if (_ch == '7' and _yrs < 8) or (_ch in ('12', '13') and _yrs < 6):
+        _risk = True
+        break
+  case.discharge_bar_risk = _risk
+---
+id: discharge_bar_warning
+section: case_det
+question: |
+  Possible discharge-eligibility issue
+subquestion: |
+  Based on the prior bankruptcy you listed, you may **not** be eligible to
+  receive a discharge in this case.
+
+  Under 11 U.S.C. § 727(a)(8)–(9), the court will not grant a Chapter 7
+  discharge if you were granted a discharge in a prior **Chapter 7** case filed
+  within **8 years**, or a prior **Chapter 12 or 13** case filed within
+  **6 years**, before the date you file this case. This period runs from the
+  **filing date** of the prior case, not the date the discharge was entered.
+
+  You can still file your petition, but please confirm your discharge
+  eligibility with your attorney before proceeding.
+continue button field: case.discharge_bar_acknowledged
 ---
 id: pending_bankruptcy
 question: |

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -905,6 +905,10 @@ code: |
   if case.has_previous_bankruptcy:
     case.previous_bankruptcy.there_are_any = True
     case.previous_bankruptcy.gather()
+    # Non-blocking discharge-eligibility warning (727(a)(8)/(9)); only shown
+    # when a prior granted discharge falls inside the 8/6-year window.
+    if case.discharge_bar_risk:
+      case.discharge_bar_acknowledged
   case.has_pending_bankruptcy
   if case.has_pending_bankruptcy:
     case.pending_bankruptcy.there_are_any = True
@@ -1069,7 +1073,9 @@ code: |
 ---
 code: |
   case.previous_bankruptcy[i].district
+  case.previous_bankruptcy[i].chapter
   case.previous_bankruptcy[i].when
+  case.previous_bankruptcy[i].discharge_granted
   case.previous_bankruptcy[i].case_number
   case.previous_bankruptcy[i].complete = True
 ---

--- a/tests/discharge-bar-warning.spec.ts
+++ b/tests/discharge-bar-warning.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Substantive-law regression: the app warns a filer who may be ineligible for a
+ * discharge under 11 U.S.C. 727(a)(8)/(9) -- a prior Chapter 7 discharge in a
+ * case FILED within 8 years (or Chapter 12/13 within 6 years) before this
+ * petition. The clock runs from the prior case's filing date, not the discharge
+ * date (confirmed William Franck, ERLS, June 2026). The warning is non-blocking.
+ *
+ * Scenario: NE single filer, non-consumer-debt (fast means-test path), who lists
+ * one prior Chapter 7 case filed ~3 years ago WITH a discharge granted. The
+ * warning screen must appear; the filer acknowledges it and finishes to PDF.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  walkToMeansTestStart,
+  navigateMeansTest,
+  navigateBusiness,
+  navigateHazardousProperty,
+  navigateCreditCounseling,
+  navigateDynamicPhase,
+} from './navigation-helpers';
+import {
+  b64,
+  waitForDaPageLoad,
+  clickContinue,
+  clickYesNoButton,
+  selectYesNoRadio,
+  fillByName,
+  clickNthByName,
+} from './helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+const SCN = { ...SIMPLE_SINGLE, name: 'discharge-bar-warning' };
+
+test.setTimeout(420_000);
+
+test('prior Chapter 7 discharge within 8 years triggers the discharge-eligibility warning', async ({ page }) => {
+  await walkToMeansTestStart(page, SCN);
+  await navigateMeansTest(page, {}); // non-consumer debts → short means-test path
+
+  // payment_method — pay the whole fee.
+  await waitForDaPageLoad(page);
+  await page.locator('label').filter({ hasText: 'I will pay the entire fee when I file my petition' }).click();
+  await clickContinue(page);
+
+  // previous_bankruptcy — YES.
+  await waitForDaPageLoad(page);
+  await clickYesNoButton(page, 'case.has_previous_bankruptcy', true);
+
+  // previous_bankruptcy_details (list collect): district, chapter 7, filed
+  // ~3 years ago, discharge granted, case number.
+  await waitForDaPageLoad(page);
+  await page.locator(`#${b64('case.previous_bankruptcy[0].district')}`).selectOption({ index: 1 });
+  await page.locator(`#${b64('case.previous_bankruptcy[0].chapter')}`).selectOption('7');
+  await page.locator(`#${b64('case.previous_bankruptcy[0].when')}`).fill('2023-06-19');
+  await selectYesNoRadio(page, 'case.previous_bankruptcy[0].discharge_granted', true);
+  await fillByName(page, b64('case.previous_bankruptcy[0].case_number'), '23-40123');
+  await clickContinue(page);
+
+  // The list-collect gather completes on Continue (one item), so the flow goes
+  // straight to discharge_bar_warning — the screen under test.
+  await waitForDaPageLoad(page);
+  const heading = ((await page.locator('h1').first().textContent()) || '').toLowerCase();
+  expect(heading).toContain('discharge-eligibility');
+  const body = ((await page.locator('body').textContent()) || '').toLowerCase();
+  expect(body).toContain('727(a)(8)');
+  expect(body).toContain('filing date');
+
+  // Acknowledge and finish the interview to PDF.
+  await clickNthByName(page, b64('case.discharge_bar_acknowledged'), 0);
+
+  await waitForDaPageLoad(page);
+  await clickYesNoButton(page, 'case.has_pending_bankruptcy', false);
+  await waitForDaPageLoad(page);
+  await clickYesNoButton(page, 'case.rents_residence', false);
+  await waitForDaPageLoad(page);
+  await clickNthByName(page, b64('case_final'), 0);
+
+  await navigateBusiness(page);
+  await navigateHazardousProperty(page);
+  await navigateCreditCounseling(page, SCN);
+  await navigateDynamicPhase(page, SCN);
+
+  await finishAndAssertAllPdfs(page);
+});

--- a/tests/fixtures/yaml-question-ids.snapshot.txt
+++ b/tests/fixtures/yaml-question-ids.snapshot.txt
@@ -16,6 +16,7 @@ docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:debtor_alias
 docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:debtor_another
 docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:debtor_basic_info
 docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:debtor_final
+docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:discharge_bar_warning
 docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:district_amended
 docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:district_case_number
 docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml:district_final


### PR DESCRIPTION
## What
The app collected prior bankruptcies but never flagged that a prior discharge can **bar a discharge** in this case. Per William Franck (ERLS, June 2026): a prior **Chapter 7** discharge in a case **filed** within **8 years**, or a **Chapter 12/13** discharge in a case filed within **6 years**, before this petition bars the discharge — 11 U.S.C. § 727(a)(8)/(9). The clock runs from the prior case's **filing date**, not the discharge date, and only a **granted** discharge triggers the bar.

## Changes
- **`101-question-blocks.yml`** — add `chapter` and `discharge_granted` fields (and a clearer "When was this case filed?" label) to `previous_bankruptcy_details`; add a `discharge_bar_risk` code block and a **non-blocking** `discharge_bar_warning` screen shown only when a prior granted discharge falls inside the 8/6-year window.
- **`voluntary-petition.yml`** — enumerate the two new fields in the per-item `complete` block (rule 7); seek the warning after the gather when `discharge_bar_risk`.
- The warning **does not block filing** (a debtor may still file without a discharge); it advises confirming eligibility with the attorney.
- **`tests/discharge-bar-warning.spec.ts`** — NE filer with a prior Ch7 discharge filed ~3 years ago → warning appears (asserts `727(a)(8)` + "filing date"), is acknowledged, and the interview finishes to PDF.

## Verification
- New spec passes end-to-end to PDF (deployed to `datest`).
- Boundary logic validated directly: Ch7 3y→warn, Ch7 9y→no, Ch7 no-discharge→no, Ch13 5y→warn, Ch13 7y→no, Ch7 7.9y→warn.
- Form 101 builder only reads `district`/`when`/`case_number`, untouched by the additive fields; `npm run lint` green (yaml-ids snapshot updated for the new screen).

Part of the William/ERLS June 2026 substantive-law batch (item E of 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)