### PR TITLE
SD wildcard: tier $7,000 head-of-family / $5,000 (SDCL 43-45-4)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
@@ -102,6 +102,21 @@ fields:
       - State exemptions: You are claiming state and federal nonbankruptcy exemptions.
       - Federal exemptions: You are claiming federal exemptions.
 ---
+id: sd_head_of_family
+section: schedule_c
+question: |
+  Are you the head of a family?
+subquestion: |
+  South Dakota lets you protect property that has no other exemption using a
+  "wildcard" exemption. The amount is **$7,000 if you are the head of a family**
+  and **$5,000 if you are not** (SDCL 43-45-4).
+
+  You are generally the **head of a family** if you are married, or if you
+  support a dependent — for example a child, or another relative who lives with
+  you and relies on you. If you are not sure which applies to you, your attorney
+  can confirm.
+yesno: prop.head_of_family
+---
 id: exempt_property_any_exist
 section: schedule_c
 question: |

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -435,6 +435,11 @@ code: |
   # confused filers and didn't change behavior — selecting "federal" still
   # showed the state exemptions (Phil/Roxanne feedback). Default it and skip.
   prop.exempt_property.exemption_type = 'You are claiming state and federal nonbankruptcy exemptions.'
+  # SD wildcard (SDCL 43-45-4) is tiered: $7,000 for a head of a family, $5,000
+  # otherwise. NE wildcard is not tiered, so ask only South Dakota filers
+  # (clinic decision, June 2026). compute_exemption_totals reads prop.head_of_family.
+  if 'south dakota' in str(debtor[0].address.state).lower():
+    prop.head_of_family
   prop.exempt_property.properties.gather()
   # Ask the debtor instead of forcing False (Roxanne feedback: the review showed
   # "Claiming Homestead Exemption: No" regardless of input).

--- a/docassemble/BankruptcyClinic/data/static/exemptions.js
+++ b/docassemble/BankruptcyClinic/data/static/exemptions.js
@@ -38,7 +38,7 @@ const southDakotaExemptions = {
   homestead: { law: 'Homestead (SDCL 43-31-1 – 43-31-6)', limit: 0, amount: 0 }, // Unlimited
   homestead_proceeds: { law: 'Homestead, proceeds of sale (SDCL 43-31-4)', limit: 0, amount: 0 }, // Unlimited
   household_goods: { law: 'Furniture and bedding (SDCL 43-45-5(5))', limit: 0, amount: 0 }, // Unlimited
-  wildcard: { law: 'Wildcard (SDCL 43-5-4)', limit: 6000, amount: 0 },
+  wildcard: { law: 'Wildcard (SDCL 43-45-4)', limit: 5000, amount: 0 }, // SDCL 43-45-4 floor: $5,000 single / $7,000 head of family (the head-of-family bump is applied server-side in objects.py)
   personal_property: { law: 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)', limit: 0, amount: 0 },
   domestic_support: { law: 'alimony, maintenance, or support of the debtor (SDCL 43-45-2)', limit: 0, amount: 0 },
   health_aids: { law: 'Health Aids (SDCL 43-45-2)', limit: 0, amount: 0 },

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -5,7 +5,7 @@ SOUTH_DAKOTA_EXEMPTIONS = {
     'homestead': 'Homestead (SDCL 43-31-1 – 43-31-6)',
     'homestead_proceeds': 'Homestead, proceeds of sale (SDCL 43-31-4)',
     'household_goods': 'Furniture and bedding (SDCL 43-45-5(5))',
-    'wildcard': 'Wildcard (SDCL 43-5-4)',
+    'wildcard': 'Wildcard (SDCL 43-45-4)',
     'personal_property': 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)',
     'domestic_support': 'Alimony, maintenance, or support of the debtor (SDCL 43-45-2)',
     'health_aids': 'Health aids (SDCL 43-45-2)',
@@ -304,13 +304,17 @@ def get_median_family_income(state, household_size):
     return table[4] + (hs - 4) * DOJ_MEDIAN_ADDITIONAL_PER_PERSON
 
 
-def get_exemption_limits(user_state):
+def get_exemption_limits(user_state, head_of_family=False):
     """
     Returns a dict of exemption category -> dollar limit for the given state.
     A limit of 0 means unlimited.
 
     Args:
         user_state (str): The user's state (e.g., "Nebraska", "South Dakota")
+        head_of_family (bool): SD wildcard (SDCL 43-45-4) is tiered — $7,000 for
+            a head of a family, $5,000 otherwise (William Franck, ERLS,
+            June 2026). Defaults to the $5,000 single-filer floor so the static
+            caps-sync gate and any context-free caller see the conservative cap.
 
     Returns:
         dict: {category_key: dollar_limit_or_0_for_unlimited}
@@ -325,7 +329,7 @@ def get_exemption_limits(user_state):
             'homestead': 0,          # Unlimited
             'homestead_proceeds': 0,  # Unlimited
             'household_goods': 0,     # Unlimited (SD doesn't specify a dollar limit on furniture/bedding)
-            'wildcard': 6000,
+            'wildcard': 7000 if head_of_family else 5000,  # SDCL 43-45-4 (William Franck, ERLS, June 2026)
             'personal_property': 0,   # Unlimited
             'health_aids': 0,         # Unlimited
             'tools': 0,              # Unlimited
@@ -404,8 +408,11 @@ def compute_exemption_totals(prop, debtor_state, num_debtors=1):
         _n = 1
     if _n < 1:
         _n = 1
+    # SD wildcard is tiered on head-of-family status (SDCL 43-45-4); read it off
+    # the property object (asked of SD filers, defaults False = $5,000 floor).
+    _hof = bool(getattr(prop, 'head_of_family', False))
     limits = {cat: (lim * _n if lim and lim > 0 else 0)
-              for cat, lim in get_exemption_limits(debtor_state).items()}
+              for cat, lim in get_exemption_limits(debtor_state, head_of_family=_hof).items()}
 
     # Map every supported state's law string -> category key. The user can pick
     # any state's law from the unified dropdowns, so the tracker has to recognize

--- a/tests/fixtures/yaml-question-ids.snapshot.txt
+++ b/tests/fixtures/yaml-question-ids.snapshot.txt
@@ -110,6 +110,7 @@ docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:exempt_prop
 docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:exempt_property_details
 docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:homestead_exemption
 docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:schedule_c_review
+docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:sd_head_of_family
 docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml:schedule_d_review
 docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml:secured_claim_details
 docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml:secured_creditors_add_another

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -438,10 +438,18 @@ export async function navigateExemptionSection(page: Page) {
     await clickContinue(page);
   }
 
+  // SD-only: "Are you the head of a family?" gates the SDCL 43-45-4 wildcard
+  // tier ($7,000 vs $5,000). Only shown for South Dakota filers; answer Yes.
+  await waitForDaPageLoad(page);
+  const hofField = page.locator(`button[name="${b64('prop.head_of_family')}"]`);
+  if (await hofField.count() > 0) {
+    await clickYesNoButton(page, 'prop.head_of_family', true);
+    await waitForDaPageLoad(page);
+  }
+
   // "Do you have any property to claim as exempt?" — this gate is SKIPPED when
   // exemptions were claimed inline (auto-populated into Schedule C). Only answer
   // it if it actually appears.
-  await waitForDaPageLoad(page);
   const exemptGate = page.locator(`[name="${b64('prop.exempt_property.properties.there_are_any')}"]`);
   if (await exemptGate.count() > 0) {
     await clickYesNoButton(page, 'prop.exempt_property.properties.there_are_any', false);

--- a/tests/sd-head-of-family-wildcard.spec.ts
+++ b/tests/sd-head-of-family-wildcard.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Substantive-law regression: the South Dakota wildcard exemption (SDCL 43-45-4)
+ * is tiered -- $7,000 for a head of a family, $5,000 otherwise (confirmed
+ * William Franck, ERLS, June 2026). The clinic chose to ask the filer directly.
+ *
+ * This test confirms the "Are you the head of a family?" question appears for a
+ * South Dakota filer (with the SDCL 43-45-4 / $7,000 explanation), is answered,
+ * and the interview finishes to PDF. (NE filers never see it -- gated on state.)
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  navigateToDebtorPage,
+  fillDebtorAndAdvance,
+  passDebtorFinal,
+  navigatePropertySection,
+  navigateExemptionSection,
+  navigateCreditorLibraryPicker,
+  navigateSecuredCreditors,
+  navigateUnsecuredCreditors,
+  navigateContractsLeases,
+  navigateCommunityProperty,
+  navigateIncome,
+  navigateExpenses,
+  navigateFinancialAffairs,
+  navigateReporting,
+  navigatePersonalLeases,
+  navigateMeansTest,
+  navigateCaseDetails,
+  navigateBusiness,
+  navigateHazardousProperty,
+  navigateCreditCounseling,
+  navigateDynamicPhase,
+} from './navigation-helpers';
+import { waitForDaPageLoad, clickYesNoButton } from './helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+const SD_SINGLE = {
+  ...SIMPLE_SINGLE,
+  name: 'sd-head-of-family',
+  district: 'District of South Dakota',
+  debtor: {
+    first: 'Robert', middle: 'A', last: 'Johnson',
+    street: '321 Pine Ln', city: 'Sioux Falls', state: 'South Dakota', zip: '57101',
+    countyIndex: 2, taxIdType: 'ssn' as const, taxId: '444-55-6666',
+  },
+  property: {},
+};
+
+test.setTimeout(420_000);
+
+test('SD filer is asked the head-of-family question for the SDCL 43-45-4 wildcard tier', async ({ page }) => {
+  await navigateToDebtorPage(page, SD_SINGLE);
+  await fillDebtorAndAdvance(page, SD_SINGLE.debtor);
+  await passDebtorFinal(page);
+  await navigatePropertySection(page, SD_SINGLE);
+
+  // The head-of-family question appears at the start of the exemption section
+  // for a South Dakota filer.
+  await waitForDaPageLoad(page);
+  const heading = ((await page.locator('h1').first().textContent()) || '').toLowerCase();
+  expect(heading).toContain('head of a family');
+  const body = ((await page.locator('body').textContent()) || '').toLowerCase();
+  expect(body).toContain('43-45-4');
+  expect(body).toContain('$7,000');
+
+  await clickYesNoButton(page, 'prop.head_of_family', true);
+
+  // Finish the interview to PDF (navigateExemptionSection skips the already
+  // answered head-of-family screen).
+  await navigateExemptionSection(page);
+  await navigateCreditorLibraryPicker(page);
+  await navigateSecuredCreditors(page, SD_SINGLE);
+  await navigateUnsecuredCreditors(page, SD_SINGLE);
+  await navigateContractsLeases(page);
+  await navigateCommunityProperty(page);
+  await navigateIncome(page, SD_SINGLE);
+  await navigateExpenses(page, SD_SINGLE.rentExpense, 0);
+  await navigateFinancialAffairs(page, SD_SINGLE);
+  await navigateReporting(page);
+  await navigatePersonalLeases(page);
+  await navigateMeansTest(page, {});
+  await navigateCaseDetails(page);
+  await navigateBusiness(page);
+  await navigateHazardousProperty(page);
+  await navigateCreditCounseling(page, SD_SINGLE);
+  await navigateDynamicPhase(page, SD_SINGLE);
+
+  await finishAndAssertAllPdfs(page);
+});


### PR DESCRIPTION
## What
The SD wildcard was a flat **$6,000** citing the typo'd "SDCL 43-5-4". Per William Franck (ERLS, June 2026) it is **SDCL 43-45-4**: **$7,000 for a head of a family, $5,000 otherwise**. Per your call, the app asks the filer directly which tier applies.

(SD has **no** separate motor-vehicle exemption — a vehicle uses the wildcard. That already held: `get_exemption_choices` skips the absent SD `motor_vehicle` category, so SD's vehicle dropdown only offers Wildcard.)

## Changes
- **`objects.py`** — fix citation `43-5-4`→`43-45-4`; `get_exemption_limits` gains a `head_of_family` arg (SD wildcard `7000 if head_of_family else 5000`, default 5000 floor so the static caps-sync gate stays conservative); `compute_exemption_totals` reads `prop.head_of_family` and threads it through (no call-site changes).
- **`exemptions.js`** — same citation fix; client tracker uses the $5,000 floor (head-of-family bump applied server-side), keeping caps-sync in sync.
- **`voluntary-petition.yml`** — ask `prop.head_of_family` for South Dakota filers only.
- **`106C-question-blocks.yml`** — the head-of-family yes/no question, explaining the $7,000/$5,000 tiers and what "head of a family" means.
- **`navigation-helpers.ts`** — `navigateExemptionSection` answers the SD-only question when present.
- **`tests/sd-head-of-family-wildcard.spec.ts`** — SD filer is asked the question (asserts `43-45-4` + `$7,000`), answers it, finishes to PDF.

## Verification
- Tiering: `get_exemption_limits('South Dakota')['wildcard']` = 5000 (default) / 7000 (head_of_family); NE unaffected (5970).
- New SD spec + SD joint-couple + NE simple-single all pass to PDF; `npm run lint` green (yaml-ids snapshot updated).

Part of the William/ERLS June 2026 substantive-law batch (item B of 7).

## ⚠️ One legal-definition follow-up for William
The amounts are confirmed, but the *trigger* — what makes a filer a "head of a family" under SDCL 43-45-4 — was a clinic UX choice (ask directly), not William's confirmed definition. The question's explanatory text says "married, or supporting a dependent." Worth a one-line confirmation from William that this framing is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)