### PR TITLE
Fee waiver: 150% federal poverty line + post-filing checklist (items F, G)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -449,14 +449,14 @@ fields:
 under: |
   Note:
 
-  Your current overall income is estimated to be: ${ currency(overallIncome) }
+  Your estimated annual household income is: ${ currency(annualIncome) }
 
-  DOJ median family income for a household of ${ int(monthly_income.median_dependents) } is: ${ currency(medianFamilyIncome) }
+  150% of the federal poverty guideline for a household of ${ int(monthly_income.median_dependents) } is: ${ currency(povertyThreshold150) }
 
-  % if overallIncome < medianFamilyIncome:
-  You may qualify for a fee waiver!
+  % if feeWaiverLikely:
+  Based on income, you may qualify to have the filing fee waived (a judge still must approve it, and only if you also cannot pay in installments).
   % else:
-  Sorry, you do not qualify for the fee waiver.
+  Your income appears to be above 150% of the poverty line, so a fee waiver is unlikely. You may still be able to pay the fee in installments.
   % endif
 
   If you choose to pay the entire fee please check with the clerk's office in your local court for more details about how you may pay.
@@ -503,7 +503,13 @@ code: |
     _state = str(value('monthly_income.median_state')).lower()
   else:
     _state = str(debtor[0].address.state).lower() if defined('debtor[0].address.state') else 'nebraska'
-  medianFamilyIncome = get_median_family_income(_state, _household_size)
+  # Fee waiver (28 U.S.C. 1930(f)): a Chapter 7 fee may be waived only if income
+  # is below 150% of the federal poverty guideline for the household size (NOT
+  # the means-test median family income, which is much higher) — William Franck,
+  # ERLS, June 2026. overallIncome is monthly, so annualize before comparing.
+  annualIncome = overallIncome * 12
+  povertyThreshold150 = get_poverty_guideline(_household_size) * 1.5
+  feeWaiverLikely = annualIncome < povertyThreshold150
 
 ---
 id: previous_bankruptcy
@@ -1361,6 +1367,28 @@ subquestion: |
   [**Download the creditor matrix** (creditor_matrix.txt)](${ mailing_matrix_file.url_for(attachment=True) })
 
   Open the downloaded file to print it, or upload it directly to CM/ECF.
+
+  ---
+
+  #### After you file — don't forget
+
+  **1. Take the second credit-counseling course (debtor education).** After you
+  file, you must complete a *second* course — a "debtor education" or "financial
+  management" course from an approved provider — and file the certificate
+  (Official Form 423). **You will not receive your discharge without it.**
+
+  **2. Bring these documents to your § 341 meeting of creditors.** The trustee
+  will ask for them before the meeting:
+
+  * Photo identification (for example, a driver's license)
+  * Proof of your Social Security number (for example, your Social Security card)
+  * Complete copies of your last two years' tax returns, including W-2s and 1099s
+  * Statements for each of your financial accounts covering the date you filed
+  * Copies of your pay/income statements from shortly before and after you filed
+  * Lien verifications for any secured creditors with an interest in your property
+
+  Your attorney can help you gather these and tell you the date, time, and place
+  of your § 341 meeting.
 allow downloading: True
 attachment code: |
   conclusion_attachments

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -304,6 +304,37 @@ def get_median_family_income(state, household_size):
     return table[4] + (hs - 4) * DOJ_MEDIAN_ADDITIONAL_PER_PERSON
 
 
+# HHS Federal Poverty Guidelines (48 contiguous states + DC) for the bankruptcy
+# fee-waiver test: a Chapter 7 fee may be waived only if income is below 150% of
+# the poverty line for the household size and the filer cannot pay in
+# installments (28 U.S.C. 1930(f); William Franck, ERLS, June 2026 — the median
+# family income previously used here was the wrong, much higher threshold).
+# 2026 figures, published in the Federal Register Jan 15, 2026.
+# Source: https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines
+# NEXT REVIEW: 2027 guidelines (published ~Jan 2027).
+HHS_POVERTY_GUIDELINES_2026 = {
+    1: 15960, 2: 21640, 3: 27320, 4: 33000,
+    5: 38680, 6: 44360, 7: 50040, 8: 55720,
+}
+HHS_POVERTY_ADDITIONAL_PER_PERSON = 5680
+
+
+def get_poverty_guideline(household_size):
+    """Annual 100% HHS poverty guideline (2026, 48 contiguous states + DC) for
+    the household size. Households over 8 add $5,680 per additional person. Bad
+    input falls back to a household of 1. NE and SD are both contiguous, so the
+    single contiguous table applies to every filer this interview supports."""
+    try:
+        hs = int(float(household_size))
+    except (TypeError, ValueError):
+        hs = 1
+    if hs < 1:
+        hs = 1
+    if hs <= 8:
+        return HHS_POVERTY_GUIDELINES_2026[hs]
+    return HHS_POVERTY_GUIDELINES_2026[8] + (hs - 8) * HHS_POVERTY_ADDITIONAL_PER_PERSON
+
+
 def get_exemption_limits(user_state, head_of_family=False):
     """
     Returns a dict of exemption category -> dollar limit for the given state.

--- a/tests/fee-waiver-poverty-line.spec.ts
+++ b/tests/fee-waiver-poverty-line.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Substantive-law regression: the fee-waiver eligibility hint uses 150% of the
+ * federal poverty guideline (28 U.S.C. 1930(f)), NOT the means-test median
+ * family income (which is far higher) -- confirmed William Franck, ERLS,
+ * June 2026.
+ *
+ * 2026 HHS guideline, household of 1 (48 contiguous states): $15,960; 150% =
+ * $23,940/yr. A $1,000/mo filer ($12,000/yr) is below -> "may qualify"; a
+ * $2,800/mo filer ($33,600/yr) is above -> "unlikely". Under the OLD code both
+ * compared to the ~$65,292 median and wrongly showed "may qualify".
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  walkToMeansTestStart,
+  navigateMeansTest,
+  navigateCaseDetails,
+  navigateBusiness,
+  navigateHazardousProperty,
+  navigateCreditCounseling,
+  navigateDynamicPhase,
+} from './navigation-helpers';
+import { waitForDaPageLoad } from './helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+test.setTimeout(420_000);
+
+async function reachPaymentMethod(page: import('@playwright/test').Page, scn: any) {
+  await walkToMeansTestStart(page, scn);
+  await navigateMeansTest(page, {}); // non-consumer → short path, lands on payment_method
+  await waitForDaPageLoad(page);
+  return ((await page.locator('body').textContent()) || '').toLowerCase();
+}
+
+test('below 150% of poverty → fee waiver looks likely', async ({ page }) => {
+  const LOW = {
+    ...SIMPLE_SINGLE,
+    name: 'fee-waiver-low',
+    income: { ...SIMPLE_SINGLE.income, grossWages: '1000' },
+  };
+  const body = await reachPaymentMethod(page, LOW);
+
+  expect(body).toContain('150% of the federal poverty guideline');
+  expect(body).toContain('$23,940.00');           // 150% FPL for household of 1
+  expect(body).toContain('may qualify to have the filing fee waived');
+
+  await navigateCaseDetails(page);
+  await navigateBusiness(page);
+  await navigateHazardousProperty(page);
+  await navigateCreditCounseling(page, LOW);
+  await navigateDynamicPhase(page, LOW);
+  await finishAndAssertAllPdfs(page);
+});
+
+test('above 150% of poverty → fee waiver looks unlikely', async ({ page }) => {
+  const HIGH = { ...SIMPLE_SINGLE, name: 'fee-waiver-high' }; // $2,800/mo
+  const body = await reachPaymentMethod(page, HIGH);
+
+  expect(body).toContain('$23,940.00');
+  expect(body).toContain('above 150% of the poverty line');
+
+  await navigateCaseDetails(page);
+  await navigateBusiness(page);
+  await navigateHazardousProperty(page);
+  await navigateCreditCounseling(page, HIGH);
+  await navigateDynamicPhase(page, HIGH);
+  await finishAndAssertAllPdfs(page);
+});


### PR DESCRIPTION
Two William/ERLS June 2026 items, both Form 101 territory.

## F — Fee waiver uses 150% of the federal poverty line
The eligibility hint compared household income to the means-test **DOJ median family income** (~$65k for a household of 1) — far above the real standard. **28 U.S.C. § 1930(f)** waives a Chapter 7 fee only if income is **below 150% of the federal poverty line** and the filer cannot pay in installments.
- **`objects.py`** — add `get_poverty_guideline()` + the **2026 HHS Federal Poverty Guidelines** (48 contiguous states), verified against [aspe.hhs.gov](https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines) and the [Jan 15 2026 Federal Register](https://www.federalregister.gov/documents/2026/01/15/2026-00755/annual-update-of-the-hhs-poverty-guidelines). NEXT REVIEW noted for the 2027 table.
- **`101-question-blocks.yml`** — `poverty_calc` annualizes household income and compares to 150% of the guideline; the payment-method note shows annual income, the 150% threshold, and an accurate likely/unlikely message.

## G — Post-filing checklist on the conclusion page
Reminds filers to take the **second (debtor-education) course** and file **Form 423** — no discharge without it — and lists the documents the trustee wants for the **§ 341 meeting** (photo ID, SSN proof, last 2 years' returns w/ W-2s/1099s, account statements covering the filing date, pay statements before/after filing, lien verifications). Document list per the ERLS trustee (William Franck).

## Verification
- `tests/fee-waiver-poverty-line.spec.ts`: $1,000/mo filer → "may qualify" against the **$23,940** (150% FPL, household 1) threshold; $2,800/mo filer → "above 150% of the poverty line". Both run to PDF.
- `get_poverty_guideline` boundary-checked (h1 $15,960 / 150% $23,940, h9 $61,400). `npm run lint` green.

Items F & G of the William/ERLS June 2026 substantive-law batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)