### PR TITLE
Exemptions: screen for the 730-day domicile rule (522(b)(3)(A))

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
@@ -102,6 +102,31 @@ fields:
       - State exemptions: You are claiming state and federal nonbankruptcy exemptions.
       - Federal exemptions: You are claiming federal exemptions.
 ---
+id: domicile_two_years
+section: schedule_c
+question: |
+  Have you lived in ${ debtor[0].address.state } for at least the last 2 years?
+subquestion: |
+  Bankruptcy law uses the state where you have lived for the **last 2 years
+  (730 days)** to decide which exemptions you can claim
+  (11 U.S.C. § 522(b)(3)(A)). If you moved to ${ debtor[0].address.state } more
+  recently than that, a different state's exemptions may apply to you.
+yesno: prop.domicile_two_years
+---
+id: domicile_warning
+section: schedule_c
+question: |
+  Your exemptions may be governed by another state
+subquestion: |
+  Because you have lived in ${ debtor[0].address.state } for less than 2 years,
+  the exemptions you can claim may be governed by the state where you lived
+  before you moved here (11 U.S.C. § 522(b)(3)(A)). This tool calculates
+  **Nebraska and South Dakota** exemptions only.
+
+  You can keep going, but please confirm with your attorney which state's
+  exemptions apply to you before relying on the amounts shown here.
+continue button field: prop.domicile_warning_acknowledged
+---
 id: sd_head_of_family
 section: schedule_c
 question: |

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -435,6 +435,13 @@ code: |
   # confused filers and didn't change behavior — selecting "federal" still
   # showed the state exemptions (Phil/Roxanne feedback). Default it and skip.
   prop.exempt_property.exemption_type = 'You are claiming state and federal nonbankruptcy exemptions.'
+  # 730-day domicile rule (11 U.S.C. 522(b)(3)(A)): the exemptions a debtor may
+  # claim are governed by the state where they were domiciled for the 730 days
+  # before filing. Screen recent movers and warn (non-blocking) — this tool only
+  # computes NE/SD exemptions (William Franck, ERLS, June 2026).
+  prop.domicile_two_years
+  if not prop.domicile_two_years:
+    prop.domicile_warning_acknowledged
   # SD wildcard (SDCL 43-45-4) is tiered: $7,000 for a head of a family, $5,000
   # otherwise. NE wildcard is not tiered, so ask only South Dakota filers
   # (clinic decision, June 2026). compute_exemption_totals reads prop.head_of_family.

--- a/tests/domicile-730-day-warning.spec.ts
+++ b/tests/domicile-730-day-warning.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Substantive-law regression: the app screens for the 730-day domicile rule
+ * (11 U.S.C. 522(b)(3)(A)) -- a debtor who has lived in the filing state for
+ * less than 2 years may have to use another state's exemptions. The app only
+ * computes NE/SD exemptions, so it warns (non-blocking) and tells the filer to
+ * confirm the governing state with their attorney (William Franck, ERLS,
+ * June 2026).
+ *
+ * Scenario: a NE filer answers "No" (lived here < 2 years) -> warning appears,
+ * is acknowledged, and the interview finishes to PDF.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import {
+  navigateToDebtorPage,
+  fillDebtorAndAdvance,
+  passDebtorFinal,
+  navigatePropertySection,
+  navigateExemptionSection,
+  navigateCreditorLibraryPicker,
+  navigateSecuredCreditors,
+  navigateUnsecuredCreditors,
+  navigateContractsLeases,
+  navigateCommunityProperty,
+  navigateIncome,
+  navigateExpenses,
+  navigateFinancialAffairs,
+  navigateReporting,
+  navigatePersonalLeases,
+  navigateMeansTest,
+  navigateCaseDetails,
+  navigateBusiness,
+  navigateHazardousProperty,
+  navigateCreditCounseling,
+  navigateDynamicPhase,
+} from './navigation-helpers';
+import { b64, waitForDaPageLoad, clickYesNoButton, clickNthByName } from './helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+const SCN = { ...SIMPLE_SINGLE, name: 'domicile-730-warning' };
+
+test.setTimeout(420_000);
+
+test('recent mover (< 2 years) gets the 730-day domicile warning', async ({ page }) => {
+  await navigateToDebtorPage(page, SCN);
+  await fillDebtorAndAdvance(page, SCN.debtor);
+  await passDebtorFinal(page);
+  await navigatePropertySection(page, SCN);
+
+  // domicile_two_years question — answer No (lived here < 2 years).
+  await waitForDaPageLoad(page);
+  const qHeading = ((await page.locator('h1').first().textContent()) || '').toLowerCase();
+  expect(qHeading).toContain('2 years');
+  await clickYesNoButton(page, 'prop.domicile_two_years', false);
+
+  // domicile_warning screen.
+  await waitForDaPageLoad(page);
+  const wHeading = ((await page.locator('h1').first().textContent()) || '').toLowerCase();
+  expect(wHeading).toContain('governed by another state');
+  const body = ((await page.locator('body').textContent()) || '').toLowerCase();
+  expect(body).toContain('522(b)(3)(a)');
+  await clickNthByName(page, b64('prop.domicile_warning_acknowledged'), 0);
+
+  // Finish to PDF (navigateExemptionSection skips the already-answered domicile
+  // screen).
+  await navigateExemptionSection(page);
+  await navigateCreditorLibraryPicker(page);
+  await navigateSecuredCreditors(page, SCN);
+  await navigateUnsecuredCreditors(page, SCN);
+  await navigateContractsLeases(page);
+  await navigateCommunityProperty(page);
+  await navigateIncome(page, SCN);
+  await navigateExpenses(page, SCN.rentExpense, 0);
+  await navigateFinancialAffairs(page, SCN);
+  await navigateReporting(page);
+  await navigatePersonalLeases(page);
+  await navigateMeansTest(page, {});
+  await navigateCaseDetails(page);
+  await navigateBusiness(page);
+  await navigateHazardousProperty(page);
+  await navigateCreditCounseling(page, SCN);
+  await navigateDynamicPhase(page, SCN);
+
+  await finishAndAssertAllPdfs(page);
+});

--- a/tests/fixtures/yaml-question-ids.snapshot.txt
+++ b/tests/fixtures/yaml-question-ids.snapshot.txt
@@ -103,6 +103,8 @@ docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml:trusts_fut
 docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml:vehicle_details
 docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml:vehicles_add_another
 docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml:vehicles_any_exist
+docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:domicile_two_years
+docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:domicile_warning
 docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:exemption_summary_overview
 docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:exemption_type_selection
 docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml:exempt_property_add_another

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -438,9 +438,17 @@ export async function navigateExemptionSection(page: Page) {
     await clickContinue(page);
   }
 
+  // 730-day domicile screen (11 U.S.C. 522(b)(3)(A)) — shown to every filer.
+  // Answer Yes (lived here 2+ years) so the recent-mover warning is skipped.
+  await waitForDaPageLoad(page);
+  const domicileField = page.locator(`button[name="${b64('prop.domicile_two_years')}"]`);
+  if (await domicileField.count() > 0) {
+    await clickYesNoButton(page, 'prop.domicile_two_years', true);
+    await waitForDaPageLoad(page);
+  }
+
   // SD-only: "Are you the head of a family?" gates the SDCL 43-45-4 wildcard
   // tier ($7,000 vs $5,000). Only shown for South Dakota filers; answer Yes.
-  await waitForDaPageLoad(page);
   const hofField = page.locator(`button[name="${b64('prop.head_of_family')}"]`);
   if (await hofField.count() > 0) {
     await clickYesNoButton(page, 'prop.head_of_family', true);


### PR DESCRIPTION
## What
The app used the filing state for exemptions without checking domicile. Under **11 U.S.C. § 522(b)(3)(A)** the exemptions a debtor may claim are governed by the state where they were domiciled for the **730 days** before filing — so a recent mover to NE/SD may have to use another state's exemptions (confirmed William Franck, ERLS, June 2026). This tool only computes NE/SD exemptions, so it screens and warns.

## Changes
- **`voluntary-petition.yml`** — at the start of the exemption section, ask `prop.domicile_two_years` ("lived here at least 2 years?"); if No, seek a non-blocking warning.
- **`106C-question-blocks.yml`** — the domicile question and the `domicile_warning` screen (explains § 522(b)(3)(A), advises confirming the governing state with the attorney). Shown to every filer; the warning does **not** block filing.
- **`navigation-helpers.ts`** — `navigateExemptionSection` answers the domicile question (Yes) so existing scenarios are unaffected.
- **`tests/domicile-730-day-warning.spec.ts`** — a filer who answers No gets the warning (asserts `522(b)(3)(A)`), acknowledges it, and finishes to PDF.

## Verification
- New spec passes to PDF; simple-single regression passes (22 cross-form invariants) — the new question is handled transparently in a normal run. `npm run lint` green (yaml-ids snapshot updated for 2 new screens).

Final item (H) of the William/ERLS June 2026 substantive-law batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)