### PR TITLE
McKenna UAT: over-required field, insurance + SOFA clarity, editable income

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -462,6 +462,7 @@ fields:
   - Year: prop.ab_other_vehicles[i].year
     datatype: number
   - Other info: prop.ab_other_vehicles[i].other_info
+    required: false
     input type: area
   - Who has an interest in the property?: prop.ab_other_vehicles[i].who
     input type: radio
@@ -2244,19 +2245,29 @@ fields:
       <br><br>
       Interest in insurance policies
 
-      Examples: Health, disability, or life insurance; health savings account (HSA); credit, homeowner's, or renter's insurance
+      Examples: Health, disability, or life insurance; health savings account (HSA); credit, homeowner's, or renter's insurance.
+
+      For each policy, enter the insurance company's name &mdash; you can include the
+      **type of policy** there too (for example, "MetLife &ndash; life" or "State Farm &ndash; auto").
+      The **value** is the policy's current cash or surrender value: what you would
+      receive if you cashed it in today. **It is not your monthly or yearly premium.**
+      Many term life, auto, and health policies have no cash value &mdash; enter $0 if that is the case.
   - Has insurance policies: prop.owed_property.has_insurance_interest
     datatype: yesnoradio
   - note: Institution 1
     show if: prop.owed_property.has_insurance_interest
-  - Institution name: prop.owed_property.first_insurance_interest_name
+  - Insurance company name: prop.owed_property.first_insurance_interest_name
     required: False
     show if: prop.owed_property.has_insurance_interest
   - Beneficiary: prop.owed_property.first_insurance_beneficiary
     required: False
     show if: prop.owed_property.has_insurance_interest
-  - Amount: prop.owed_property.first_insurance_interest_amount
+  - Current cash/surrender value of the policy: prop.owed_property.first_insurance_interest_amount
     datatype: currency
+    help: |
+      The cash or surrender value &mdash; what you would receive if you cashed in the
+      policy today. This is NOT your monthly or yearly premium. Enter $0 if the
+      policy has no cash value (most term life, auto, and health policies).
     required: False
     show if: prop.owed_property.has_insurance_interest
   - Claiming Exemption?: prop.owed_property.first_insurance_interest_has_claim
@@ -2292,14 +2303,18 @@ fields:
     datatype: yesnoradio
     show if: prop.owed_property.has_insurance_interest
     required: False
-  - Institution name: prop.owed_property.second_insurance_interest_name
+  - Insurance company name: prop.owed_property.second_insurance_interest_name
     required: False
     show if: prop.owed_property.has_second_insurance_interest
   - Beneficiary: prop.owed_property.second_insurance_beneficiary
     required: False
     show if: prop.owed_property.has_second_insurance_interest
-  - Amount: prop.owed_property.second_insurance_interest_amount
+  - Current cash/surrender value of the policy: prop.owed_property.second_insurance_interest_amount
     datatype: currency
+    help: |
+      The cash or surrender value &mdash; what you would receive if you cashed in the
+      policy today. This is NOT your monthly or yearly premium. Enter $0 if the
+      policy has no cash value (most term life, auto, and health policies).
     required: False
     show if: prop.owed_property.has_second_insurance_interest
   - Claiming Exemption?: prop.owed_property.second_insurance_interest_has_claim
@@ -2336,14 +2351,18 @@ fields:
     datatype: yesnoradio
     show if: prop.owed_property.has_insurance_interest
     required: False
-  - Institution name: prop.owed_property.third_insurance_interest_name
+  - Insurance company name: prop.owed_property.third_insurance_interest_name
     required: False
     show if: prop.owed_property.has_third_insurance_interest
   - Beneficiary: prop.owed_property.third_insurance_beneficiary
     required: False
     show if: prop.owed_property.has_third_insurance_interest
-  - Amount: prop.owed_property.third_insurance_interest_amount
+  - Current cash/surrender value of the policy: prop.owed_property.third_insurance_interest_amount
     datatype: currency
+    help: |
+      The cash or surrender value &mdash; what you would receive if you cashed in the
+      policy today. This is NOT your monthly or yearly premium. Enter $0 if the
+      policy has no cash value (most term life, auto, and health policies).
     required: False
     show if: prop.owed_property.has_third_insurance_interest
   - Claiming Exemption?: prop.owed_property.third_insurance_interest_has_claim

--- a/docassemble/BankruptcyClinic/data/questions/106I-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106I-question-blocks.yml
@@ -631,6 +631,23 @@ review:
         Has other monthly income: No
       % endif
   - note: |
+      **Need to change something above? Use these buttons to go back and edit.**
+  - Revisit: debtor[0].income.employment
+    button: |
+      Employment information
+  - Revisit: debtor[0].income.income_amount_1
+    button: |
+      Monthly income (wages &amp; overtime)
+  - Revisit: debtor[0].income.tax_deduction
+    button: |
+      Payroll deductions
+  - Revisit: debtor[0].income.other_deduction
+    button: |
+      Other deductions
+  - Revisit: debtor[0].income.net_rental_business
+    button: |
+      Other income sources
+  - note: |
       <br>
       ### Other Debtor
       Employment Status: ${ debtor[1].income.employment }
@@ -685,6 +702,29 @@ review:
         Has other monthly income: No
       % endif
 
+    show if: debtor[1]
+  - note: |
+      **Need to change something above? Use these buttons to go back and edit.**
+    show if: debtor[1]
+  - Revisit: debtor[1].income.employment
+    button: |
+      The other debtor's employment information
+    show if: debtor[1]
+  - Revisit: debtor[1].income.income_amount_1
+    button: |
+      The other debtor's monthly income (wages &amp; overtime)
+    show if: debtor[1]
+  - Revisit: debtor[1].income.tax_deduction
+    button: |
+      The other debtor's payroll deductions
+    show if: debtor[1]
+  - Revisit: debtor[1].income.other_deduction
+    button: |
+      The other debtor's other deductions
+    show if: debtor[1]
+  - Revisit: debtor[1].income.net_rental_business
+    button: |
+      The other debtor's other income sources
     show if: debtor[1]
 ---
 attachment:

--- a/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
@@ -4,6 +4,13 @@ question: |
   Give details about your marital status and where you lived before
 subquestion: |
   Be as complete and accurate as possible. If two married people are filing together, both are equally responsible for supplying correct information.
+
+  % if defined('financial_affairs.debtor_count') and financial_affairs.debtor_count > 1:
+  Because you are filing jointly, for **each** place you lived in the last 3 years
+  the form also asks where Debtor 2 lived during that same period. If Debtor 2
+  lived with you, just choose **"Same address as you?" &rarr; Yes** and you will
+  not have to re-type the address.
+  % endif
 validation code: |
   if financial_affairs.lived_elsewhere:
     # The address fields are required:False so that answering "No" never blocks
@@ -847,6 +854,10 @@ fields:
 section: form_107
 question: |
   Explain the sources of debtor 2's income
+subquestion: |
+  This is a separate question for the co-debtor (Debtor 2). The court needs each
+  filer's income history, so you are answering for Debtor 2 here even though you
+  already gave your own income on the previous screen.
 fields:
   - note: |
       Did debtor 2 have any income from employment or from operating a business during this year or the two previous calendar years?

--- a/tests/income-review-edit.spec.ts
+++ b/tests/income-review-edit.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Verification for McKenna Wenger's June 2026 feedback (Legal Aid of Nebraska).
+ *
+ * Issue #3 — "I wanted to go back and fix my income but it just keeps throwing
+ * me around. Resume brings you to what you're currently working on, Back brings
+ * you to the whole other category before, and it doesn't seem like you can go in
+ * and edit again."
+ *
+ * Root cause: the Schedule I review screen (`event: schedule_i`, reachable from
+ * the section nav "Your Income" link OR the final-review "Revisit income" link)
+ * was DISPLAY-ONLY — a wall of `note:` text with no Edit buttons. So even when
+ * the filer reached the income review, they could look but not change anything.
+ *
+ * Fix: added per-screen `Edit:`/`button:` items to `schedule_i_review`.
+ *
+ * This spec runs a full single interview all the way through to PDF assembly
+ * (CLAUDE.md: every regression test ends at the deliverable), then exercises the
+ * exact path McKenna took — the "Your Income" section-nav link — to confirm the
+ * income review now offers working Edit buttons and an edit round-trips.
+ *
+ * (Issues #1 "other vehicles → other info required" and #2 "insurance amount
+ * label / type" are declarative form-definition + label/help changes validated
+ * by the YAML, flow, and pdf-field gates; they carry no flow-logic risk.)
+ */
+import { test, expect, Page } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { runFullInterview } from './navigation-helpers';
+import { b64, waitForDaPageLoad, clickContinue, fillById } from './helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+async function heading(page: Page): Promise<string> {
+  return (await page.locator('h1').first().textContent().catch(() => '')) || '';
+}
+
+async function assertNoErrorPage(page: Page) {
+  const body = (await page.locator('body').innerText()).toLowerCase();
+  expect(body).not.toContain('there was an error');
+  expect(body).not.toContain('traceback');
+  expect(body).not.toContain('infinite loop');
+}
+
+test.describe('McKenna feedback #3 — income is editable from the review screen', () => {
+  test.setTimeout(360_000);
+
+  test('full interview assembles, then income is editable from the "Your Income" nav', async ({ page }) => {
+    // 1) Drive the whole interview to the conclusion and prove the PDFs assemble.
+    await runFullInterview(page, SIMPLE_SINGLE);
+    await finishAndAssertAllPdfs(page);
+
+    // 2) McKenna's path: click "Your Income" in the section navigation. With the
+    //    schedule_i_review block (event: schedule_i) this opens the income review.
+    const yourIncome = page.getByRole('link', { name: /^your income$/i });
+    await expect(yourIncome).toBeVisible();
+    await yourIncome.click();
+    await waitForDaPageLoad(page);
+    await assertNoErrorPage(page);
+    expect((await heading(page)).toLowerCase()).toContain('review employment');
+
+    // 3) The fix: the review now offers "Revisit" buttons (it used to be
+    //    display-only). docassemble labels each button "Revisit" and renders our
+    //    descriptive text beneath it. The income screens are listed in a fixed
+    //    order: employment (0), monthly income (1), payroll (2), other
+    //    deductions (3), other income (4).
+    await expect(page.getByText('Monthly income (wages & overtime)')).toBeVisible();
+    const revisitButtons = page.getByRole('button', { name: /^revisit$/i });
+    await expect(revisitButtons).toHaveCount(5);
+
+    // 4) Click the monthly-income Revisit → land on the editable monthly-income
+    //    screen (defines income_amount_1). The income_amount_1 assertion below
+    //    confirms we opened the right screen — the screen McKenna could not get
+    //    back to before this fix.
+    await revisitButtons.nth(1).click();
+    await waitForDaPageLoad(page);
+    await assertNoErrorPage(page);
+
+    const amtField = page.locator(`#${b64('debtor[0].income.income_amount_1')}`);
+    await expect(amtField).toBeVisible();      // the income IS editable again
+
+    // 5) Change the value and continue — the edit must submit without error.
+    await fillById(page, b64('debtor[0].income.income_amount_1'), '4321');
+    await clickContinue(page);
+    await waitForDaPageLoad(page);
+    await assertNoErrorPage(page);
+  });
+});


### PR DESCRIPTION
Addresses June 2026 UAT feedback from McKenna Wenger (intern, Legal Aid of Nebraska).

## Fixes
1. **Schedule A/B "other vehicles" over-required "Other info"** — the line-4 ("other vehicles": boats, trailers, ATVs…) `other_info` field was required, while the identical field on the line-3 vehicles screen is optional. Added `required: false` to match. *(106AB)*
2. **"Interest in insurance policies" was confusing** — "Amount" was ambiguous (premium vs. value). Relabeled to **"Current cash/surrender value of the policy"** with help clarifying it is *not* the monthly/yearly premium; the section note now tells filers they can include the policy type in the company name; "Institution name" → "Insurance company name". Labels/help only — **no PDF-field key changes**. *(106AB)*
3. **Could not edit income after entering it** — the Schedule I review screen (`event: schedule_i`, reached from the "Your Income" section nav or the final-review "Revisit income" link) was display-only `note:` text with no way back in. Added per-screen **Revisit buttons** (same pattern as the 106C/122A reviews). *(106I)*
4. **SOFA "asks about Debtor 2 several times"** — not a logic bug (the form legitimately needs the co-debtor's prior addresses and income), but it confused the tester. Added brief clarifying text on the residence-history and Debtor 2 income screens (joint cases only). *(107)*

## Verification
- New end-to-end spec `tests/income-review-edit.spec.ts`: full single-filer interview → **all PDFs assemble**, then navigates to the income review, confirms the Revisit buttons render, opens the monthly-income screen and edits it. **Passes.**
- Existing joint-filer regression `feedback-fixes-verify.spec.ts` (drives JOINT_COUPLE through SOFA to PDFs) **passes** — confirms the new SOFA helper text renders cleanly for joint cases.
- `npm run lint` (selectors, yaml-ids, flow-gaps, test-completeness, caps-sync, pdf-fields) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HXEGr7z2VdprY1wMHsw3g