### PR TITLE
Roxanne UAT (July 2026): domicile wording, Schedule D guidance, single debt-classification question

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -989,9 +989,20 @@ review:
       ${ counseling_table }
 ---
 #Part 6: Answer These Questions for Reporting Purposes
+# Single source of truth for the debt classification: Form 107 question 6 and
+# the 122A means-test exemption both DERIVE from this answer (see the mandatory
+# block in voluntary-petition.yml) so the interview asks only once — Roxanne
+# feedback, July 2026 ("the software asks again what kinds of debts").
 id: reporting_type
 question: |
   What kind of debts do you have?
+subquestion: |
+  For most people the answer is **Primarily consumer debts** — debts incurred
+  for personal, family, or household purposes, such as credit cards, medical
+  bills, a home mortgage, or a car loan (11 U.S.C. § 101(8)).
+
+  Choose **Primarily business debts** only if most of what you owe comes from
+  running a business.
 fields:
   - no label: reporting.reporting_type
     input type: radio

--- a/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
@@ -107,10 +107,17 @@ section: schedule_c
 question: |
   Have you lived in ${ debtor[0].address.state } for at least the last 2 years?
 subquestion: |
-  Bankruptcy law uses the state where you have lived for the **last 2 years
-  (730 days)** to decide which exemptions you can claim
-  (11 U.S.C. § 522(b)(3)(A)). If you moved to ${ debtor[0].address.state } more
-  recently than that, a different state's exemptions may apply to you.
+  This question is about the **state** you have lived in, not any one address.
+  If you have lived anywhere in ${ debtor[0].address.state } for the last
+  2 years — even if you moved between homes within the state — answer **Yes**.
+  Most people answer Yes.
+
+  Answer **No** only if you moved to ${ debtor[0].address.state } from a
+  different state within the last 2 years.
+
+  Why we ask: bankruptcy law uses the state where you have lived for the
+  **last 2 years (730 days)** to decide which exemptions you can claim
+  (11 U.S.C. § 522(b)(3)(A)).
 yesno: prop.domicile_two_years
 ---
 id: domicile_warning
@@ -118,10 +125,18 @@ section: schedule_c
 question: |
   Your exemptions may be governed by another state
 subquestion: |
-  Because you have lived in ${ debtor[0].address.state } for less than 2 years,
-  the exemptions you can claim may be governed by the state where you lived
-  before you moved here (11 U.S.C. § 522(b)(3)(A)). This tool calculates
-  **Nebraska and South Dakota** exemptions only.
+  You answered that you moved to ${ debtor[0].address.state } from a different
+  state within the last 2 years.
+
+  **Answered by mistake?** If you have actually lived in
+  ${ debtor[0].address.state } for the last 2 years (moving between homes
+  *within* the state still counts), click **Back** and change your answer —
+  you can still claim ${ debtor[0].address.state } exemptions.
+
+  If you really did move here from another state within the last 2 years, the
+  exemptions you can claim may be governed by the state where you lived before
+  (11 U.S.C. § 522(b)(3)(A)). This tool calculates **Nebraska and South
+  Dakota** exemptions only.
 
   You can keep going, but please confirm with your attorney which state's
   exemptions apply to you before relying on the amounts shown here.

--- a/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
@@ -138,8 +138,8 @@ question: |
   Tell the court about your secured claim.
 subquestion: |
   Include your home mortgage lender, vehicle loan lender, and any other
-  creditor whose debt is backed by your property. If a creditor has more than
-  one secured claim, list the creditor separately for each claim.
+  creditor holding a claim secured by your property. If a creditor has more
+  than one secured claim, list the creditor separately for each claim.
 check in: unsecured_claim_amount
 allowed to set:
   - prop.creditors[i].complete

--- a/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
@@ -57,6 +57,15 @@ id: secured_creditors_any_exist
 section: schedule_d
 question: |
   Do any creditors have claims secured by your property?
+subquestion: |
+  A **secured** creditor is one that can take specific property if you don't
+  pay — for example, a **home mortgage lender**, a **car loan lender**, or any
+  creditor with a lien on your property.
+
+  **Include your home mortgage and vehicle loan lenders here.** Earlier
+  questions about your home and vehicles only asked *how much* you owe — the
+  lenders themselves have not been listed yet. Each secured creditor must be
+  listed on this schedule (Schedule D) for your bankruptcy to cover that debt.
 yesno: prop.creditors.there_are_any
 ---
 id: secured_creditors_add_another
@@ -128,7 +137,9 @@ section: schedule_d
 question: |
   Tell the court about your secured claim.
 subquestion: |
-  If a creditor has more than one secured claim, list the creditor separately for each claim.
+  Include your home mortgage lender, vehicle loan lender, and any other
+  creditor whose debt is backed by your property. If a creditor has more than
+  one secured claim, list the creditor separately for each claim.
 check in: unsecured_claim_amount
 allowed to set:
   - prop.creditors[i].complete

--- a/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
@@ -1081,14 +1081,11 @@ edit:
   - amount_owed
   - payment_for
 ---
-id: consumer_debts_classification
-question: |
-  % if len(debtor) > 1:
-  Are either Debtor 1's or Debtor 2's debts primarily consumer debts?
-  % else:
-  Are your debts primarily consumer debts?
-  % endif
-yesno: financial_affairs.primarily_consumer_debts
+# financial_affairs.primarily_consumer_debts is no longer asked here — it is
+# DERIVED from the Form 101 Part 6 answer (reporting.reporting_type) in the
+# mandatory block of voluntary-petition.yml, so the interview asks about the
+# kind of debts only once (Roxanne feedback, July 2026). Keeping a question
+# block here too would violate the one-generator-per-variable rule (loop risk).
 ---
 id: consumer_creditor_payments
 question: |

--- a/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
@@ -15,9 +15,11 @@ id: means_test_exemptions
 section: form_122a
 question: |
   Identify any exemptions from Presumption of Abuse.
+subquestion: |
+  You already told us your debts are primarily
+  ${ 'consumer' if reporting.reporting_type == '1' else 'non-consumer' } debts,
+  so we won't ask that again.
 fields:
-  - Are your debts primarily non-consumer?: monthly_income.non_consumer_debts
-    datatype: yesnoradio
   - Are you a disabled veteran?: monthly_income.disabled_veteran
     datatype: yesnoradio
   - Are you in the Reservists or National Guard?: monthly_income.reservists

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -750,7 +750,12 @@ code: |
   financial_affairs.had_other_income
   if len(debtor) > 1:
     financial_affairs.debtor2_had_other_income
-  financial_affairs.primarily_consumer_debts
+  # Debt classification is asked ONCE — Form 101 Part 6 ("What kind of debts
+  # do you have?") — and 107 q6 + 122A derive from it (Roxanne feedback, July
+  # 2026: the interview asked the same thing three times). reporting_type:
+  # '1' = primarily consumer, '2' = primarily business, '3' = other.
+  reporting.reporting_type
+  financial_affairs.primarily_consumer_debts = (reporting.reporting_type == '1')
 
   financial_affairs.consumer_debt_payments.gather()
 
@@ -806,8 +811,9 @@ code: |
       add_creditor(_cred.name, _cred.street, _cred.city, _cred.state, _cred.zip, getattr(_cred, 'type', 'Nonpriority'))
       _cred.save_to_library = False
 
-  # Reporting — moved here so estimates auto-populate from entered data
-  reporting.reporting_type
+  # Reporting — moved here so estimates auto-populate from entered data.
+  # (reporting.reporting_type is already asked earlier, at the SOFA debt-
+  # classification point.)
   reporting.funds_for_creditors
   # Auto-calculate estimates from already-entered data
   reporting.creditor_estimate = len(prop.creditors) + len(prop.priority_claims) + len(prop.nonpriority_claims)
@@ -852,7 +858,12 @@ code: |
 
   #122a - Income and means test
   monthly_income.means_type
-  monthly_income.non_consumer_debts
+  # Derived from the single Form 101 Part 6 debt-classification answer — no
+  # longer asked on the means-test exemptions screen (Roxanne feedback, July
+  # 2026). The veteran/reservist questions are still asked (screen below).
+  monthly_income.non_consumer_debts = (reporting.reporting_type != '1')
+  monthly_income.disabled_veteran
+  monthly_income.reservists
   if monthly_income.non_consumer_debts == False and monthly_income.disabled_veteran == False and monthly_income.reservists == False:
     monthly_income.filing_status
     monthly_income.gross_wages1

--- a/tests/branch-matrix.spec.ts
+++ b/tests/branch-matrix.spec.ts
@@ -1,9 +1,11 @@
 /**
  * Branch coverage matrix — the show-if / branch-gap paths the manifest flags.
  *
- * The happy-path scenario specs all answer non_consumer_debts=Yes, which
- * short-circuits the means test entirely (no 122A income screens, no
- * review_122). That is exactly the branch where the shipped crashes lived:
+ * The happy-path scenario specs all pick "Primarily business debts" on the
+ * single Form 101 debt-kind radio (from which 107 q6 and the 122A
+ * non_consumer_debts flag now DERIVE), which short-circuits the means test
+ * entirely (no 122A income screens, no review_122). That is exactly the
+ * branch where the shipped crashes lived:
  *
  *  - B1: single + consumer debts → the 122A gross_wages2 BRANCH GAP
  *    (collected only for married-filing, read for ANY consumer-debt filer —
@@ -18,10 +20,11 @@
  * Every case runs ALL THE WAY THROUGH to PDF assembly — these crashes only
  * surface when the form builders read the variables, not mid-interview.
  */
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { SIMPLE_SINGLE, JOINT_COUPLE, TestScenario } from './fixtures';
 import { runFullInterview } from './navigation-helpers';
 import { finishAndAssertAllPdfs } from './assert-helpers';
+import { findPdf } from './pdf-helpers';
 
 test.describe('Branch matrix: means-test consumer-debt branches', () => {
   test.setTimeout(600_000);
@@ -32,7 +35,19 @@ test.describe('Branch matrix: means-test consumer-debt branches', () => {
       meansTest: { consumerDebts: true, filingStatusIndex: 0 },
     };
     await runFullInterview(page, scenario);
-    await finishAndAssertAllPdfs(page);
+    const pdfs = await finishAndAssertAllPdfs(page);
+
+    // The single Form 101 debt-kind answer must land on BOTH derived forms
+    // (107 q6 and the 101 Part 6 checkboxes) — proves the derivation reaches
+    // paper, not just that assembly doesn't crash.
+    const f101 = findPdf(pdfs, '101');
+    expect(f101?.fields['consumer_debts_true'],
+      'Form 101 Part 6 "primarily consumer" checkbox').toBeTruthy();
+    expect(f101?.fields['business_debts_true'],
+      'Form 101 Part 6 business checkbox must be unchecked').toBeFalsy();
+    const f107 = findPdf(pdfs, '107');
+    expect(f107?.fields['yesBothConsumerDebts'],
+      'Form 107 q6 consumer-debts checkbox (derived from Form 101)').toBeTruthy();
   });
 
   test('B2: joint filers + consumer debts (Married filing jointly) assembles all PDFs', async ({ page }) => {
@@ -53,5 +68,28 @@ test.describe('Branch matrix: means-test consumer-debt branches', () => {
     };
     await runFullInterview(page, scenario);
     await finishAndAssertAllPdfs(page);
+  });
+
+  test('B4: single filer + "Other" debt kind assembles all PDFs with both 101 boxes off', async ({ page }) => {
+    // The third radio option (reporting_type = '3'): reveals the optional
+    // "Other type" show-if field, derives primarily_consumer=False /
+    // non_consumer=True (means test short-circuits like business), and checks
+    // NEITHER Part 6 box on Form 101.
+    const scenario: TestScenario = {
+      ...SIMPLE_SINGLE,
+      name: 'debt-kind-other',
+      meansTest: { debtKind: 'other' },
+    };
+    await runFullInterview(page, scenario);
+    const pdfs = await finishAndAssertAllPdfs(page);
+
+    const f101 = findPdf(pdfs, '101');
+    expect(f101?.fields['consumer_debts_true'],
+      'Form 101 consumer checkbox must be unchecked for "Other"').toBeFalsy();
+    expect(f101?.fields['business_debts_true'],
+      'Form 101 business checkbox must be unchecked for "Other"').toBeFalsy();
+    const f107 = findPdf(pdfs, '107');
+    expect(f107?.fields['noConsumerDebts'],
+      'Form 107 q6 "No" checkbox (derived from Form 101 "Other")').toBeTruthy();
   });
 });

--- a/tests/feedback-fixes-verify.spec.ts
+++ b/tests/feedback-fixes-verify.spec.ts
@@ -80,9 +80,8 @@ async function consumerDebtMeansTest(page: Page, joint: boolean) {
     if (h.includes('presumption of abuse') && body.includes('select the option')) {
       await selectByName(page, b64('monthly_income.means_type'), 'There is no presumption of abuse.');
     } else if (h.includes('identify any exemptions')) {
-      // The KEY: consumer debts (NO) → drops into review_122 + poverty_calc.
-      await fillYesNoRadio(page, 'monthly_income.non_consumer_debts', false);
-      await page.waitForTimeout(150);
+      // non_consumer_debts derives from the Form 101 radio (answered consumer
+      // back at the SOFA point) → drops into review_122 + poverty_calc.
       await fillYesNoRadio(page, 'monthly_income.disabled_veteran', false);
       await page.waitForTimeout(150);
       await fillYesNoRadio(page, 'monthly_income.reservists', false);
@@ -101,7 +100,10 @@ test.describe('June 2026 feedback fixes — Schedule G lease + consumer-debt mea
   test.setTimeout(300_000);
 
   test('joint interview with an added lease and zero-income consumer means test reaches conclusion', async ({ page }) => {
-    const scenario = JOINT_COUPLE;
+    // consumerDebts:true → navigateFinancialAffairs picks "Primarily consumer
+    // debts" on the Form 101 radio, which derives non_consumer_debts=False
+    // (the consumer means-test path this spec exercises).
+    const scenario = { ...JOINT_COUPLE, meansTest: { consumerDebts: true } };
     await navigateToDebtorPage(page, scenario);
     await fillDebtorAndAdvance(page, scenario.debtor);
     if (scenario.jointFiling && scenario.spouse) {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -158,6 +158,9 @@ export interface MeansTestOptions {
    *  radio (asked at the SOFA point) → full means test. Omit/false picks
    *  "Primarily business debts" → means test short-circuits. */
   consumerDebts?: boolean;
+  /** Explicit debt-kind radio choice; overrides consumerDebts when set.
+   *  'other' short-circuits the means test like 'business' does. */
+  debtKind?: 'consumer' | 'business' | 'other';
   /** Index into the filing_status choices:
    *  0 = Not married, 1 = Married filing jointly, 2 = Married NOT filing. */
   filingStatusIndex?: 0 | 1 | 2;

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -154,7 +154,9 @@ export interface ExpenseData {
 /** Drives the 122A means-test branch. Omit (or consumerDebts: false) for the
  *  non-consumer short-circuit the happy-path helpers always took. */
 export interface MeansTestOptions {
-  /** Answer "are your debts primarily NON-consumer?" with No → full means test. */
+  /** Pick "Primarily consumer debts" on the single Form 101 debt-classification
+   *  radio (asked at the SOFA point) → full means test. Omit/false picks
+   *  "Primarily business debts" → means test short-circuits. */
   consumerDebts?: boolean;
   /** Index into the filing_status choices:
    *  0 = Not married, 1 = Married filing jointly, 2 = Married NOT filing. */

--- a/tests/fixtures/yaml-question-ids.snapshot.txt
+++ b/tests/fixtures/yaml-question-ids.snapshot.txt
@@ -163,7 +163,6 @@ docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:charitable_c
 docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:consumer_creditor_payments
 docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:consumer_debt_additional_creditors
 docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:consumer_debt_payment_details
-docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:consumer_debts_classification
 docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:environmental_hazardous_gateway
 docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:environmental_judicial_proceeding
 docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml:environmental_law_liability

--- a/tests/maximalist.spec.ts
+++ b/tests/maximalist.spec.ts
@@ -817,10 +817,13 @@ async function navigateFinancialAffairsMaximalist(page: Page) {
   await fillYesNoRadio(page, 'financial_affairs.debtor2_had_other_income', false);
   await clickContinue(page);
 
-  // Consumer debts -> Yes
-  console.log('  [financialAffairs] Consumer debts -> Yes');
+  // Debt classification — single Form 101 "what kind of debts" radio (107 q6
+  // and 122A non_consumer_debts derive from it). Consumer -> full means test.
+  console.log('  [financialAffairs] Kind of debts -> Primarily consumer');
   await waitForDaPageLoad(page);
-  await clickYesNoButton(page, 'financial_affairs.primarily_consumer_debts', true);
+  await page.locator('label').filter({ hasText: 'Primarily consumer debts' }).click();
+  await clickContinue(page);
+  await waitForDaPageLoad(page);
 
   // All list-gathers -> No
   for (const varName of [
@@ -1315,10 +1318,8 @@ async function navigateMeansTestMaximalist(page: Page) {
   await selectByName(page, b64('monthly_income.means_type'), 'There is no presumption of abuse.');
   await clickContinue(page);
 
-  console.log('  [meansTest] Exemptions (non_consumer_debts=False)');
+  console.log('  [meansTest] Exemptions (non_consumer_debts derived from Form 101 radio)');
   await waitForDaPageLoad(page);
-  await selectYesNoRadio(page, 'monthly_income.non_consumer_debts', false);
-  await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.disabled_veteran', false);
   await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.reservists', false);

--- a/tests/means-test-nonfiling-spouse.spec.ts
+++ b/tests/means-test-nonfiling-spouse.spec.ts
@@ -38,16 +38,21 @@ import { finishAndAssertAllPdfs } from './assert-helpers';
 test.setTimeout(420_000);
 
 test('non-filing spouse income is included in the means-test median comparison', async ({ page }) => {
-  await walkToMeansTestStart(page, { ...SIMPLE_SINGLE, name: 'nonfiling-spouse-cmi' });
+  await walkToMeansTestStart(page, {
+    ...SIMPLE_SINGLE,
+    name: 'nonfiling-spouse-cmi',
+    // Picks "Primarily consumer debts" at the SOFA debt-classification radio,
+    // which now drives the (derived) non_consumer_debts → full means test.
+    meansTest: { consumerDebts: true },
+  });
 
   // means_test_presumption_of_abuse
   await selectByName(page, b64('monthly_income.means_type'), 'There is no presumption of abuse.');
   await clickContinue(page);
 
-  // means_test_exemptions — consumer debts → full median comparison.
+  // means_test_exemptions — consumer debts (from the SOFA-point radio above)
+  // → full median comparison. non_consumer_debts is derived, not a field here.
   await waitForDaPageLoad(page);
-  await selectYesNoRadio(page, 'monthly_income.non_consumer_debts', false);
-  await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.disabled_veteran', false);
   await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.reservists', false);

--- a/tests/means-test-social-security.spec.ts
+++ b/tests/means-test-social-security.spec.ts
@@ -48,11 +48,10 @@ test('Social Security is excluded from the means-test median comparison', async 
   await selectByName(page, b64('monthly_income.means_type'), 'There is no presumption of abuse.');
   await clickContinue(page);
 
-  // means_test_exemptions — consumer debts (non_consumer_debts = false) drives
-  // the full 122A median comparison.
+  // means_test_exemptions — consumer debts (picked on the SOFA-point Form 101
+  // radio via meansTest.consumerDebts) drives the full 122A median comparison;
+  // non_consumer_debts is derived, not a field here.
   await waitForDaPageLoad(page);
-  await selectYesNoRadio(page, 'monthly_income.non_consumer_debts', false);
-  await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.disabled_veteran', false);
   await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.reservists', false);

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -582,9 +582,17 @@ export async function navigateFinancialAffairs(page: Page, scenario: TestScenari
     await clickContinue(page);
   }
 
-  // Consumer debts → Yes
+  // Debt classification — the single "What kind of debts do you have?" radio
+  // (Form 101 Part 6; 107 q6 + 122A non_consumer_debts derive from it). Pick
+  // consumer when the scenario drives the full means test, business otherwise
+  // so the means test keeps short-circuiting like the old non_consumer=Yes
+  // default did.
   await waitForDaPageLoad(page);
-  await clickYesNoButton(page, 'financial_affairs.primarily_consumer_debts', true);
+  await page.locator('label').filter({
+    hasText: scenario.meansTest?.consumerDebts ? 'Primarily consumer debts' : 'Primarily business debts',
+  }).click();
+  await clickContinue(page);
+  await waitForDaPageLoad(page);
 
   // All list-gathers → No
   for (const varName of [
@@ -1074,10 +1082,9 @@ export async function navigateMeansTest(page: Page, opts: MeansTestOptions = {})
   await clickContinue(page);
 
   await waitForDaPageLoad(page);
-  // non_consumer_debts=true short-circuits the means test (the happy path the
-  // helpers always took — which is why the consumer-branch crashes hid there).
-  await selectYesNoRadio(page, 'monthly_income.non_consumer_debts', !opts.consumerDebts);
-  await page.waitForTimeout(300);
+  // non_consumer_debts is no longer a field here — it derives from the Form
+  // 101 "what kind of debts" radio answered back in navigateFinancialAffairs
+  // (scenario.meansTest.consumerDebts picks consumer vs business there).
   await selectYesNoRadio(page, 'monthly_income.disabled_veteran', false);
   await page.waitForTimeout(300);
   await selectYesNoRadio(page, 'monthly_income.reservists', false);
@@ -1241,10 +1248,9 @@ export async function navigateCreditCounseling(page: Page, scenario: TestScenari
 // ════════════════════════════════════════════════════════════════════
 
 export async function navigateReporting(page: Page) {
-  await waitForDaPageLoad(page);
-  await page.locator('label').filter({ hasText: 'Primarily consumer debts' }).click();
-  await clickContinue(page);
-
+  // reporting.reporting_type ("what kind of debts") is now answered earlier,
+  // at the SOFA debt-classification point (navigateFinancialAffairs) — the
+  // reporting section starts directly at funds_for_creditors.
   await waitForDaPageLoad(page);
   await clickYesNoButton(page, 'reporting.funds_for_creditors', false);
 }

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -586,11 +586,13 @@ export async function navigateFinancialAffairs(page: Page, scenario: TestScenari
   // (Form 101 Part 6; 107 q6 + 122A non_consumer_debts derive from it). Pick
   // consumer when the scenario drives the full means test, business otherwise
   // so the means test keeps short-circuiting like the old non_consumer=Yes
-  // default did.
+  // default did. meansTest.debtKind overrides for the 'other' branch.
+  const DEBT_KIND_INDEX = { consumer: 0, business: 1, other: 2 } as const;
+  const debtKind =
+    scenario.meansTest?.debtKind ??
+    (scenario.meansTest?.consumerDebts ? 'consumer' : 'business');
   await waitForDaPageLoad(page);
-  await page.locator('label').filter({
-    hasText: scenario.meansTest?.consumerDebts ? 'Primarily consumer debts' : 'Primarily business debts',
-  }).click();
+  await selectChoiceRadio(page, 'reporting.reporting_type', DEBT_KIND_INDEX[debtKind]);
   await clickContinue(page);
   await waitForDaPageLoad(page);
 

--- a/tests/probe-means-test-consumer.spec.ts
+++ b/tests/probe-means-test-consumer.spec.ts
@@ -25,6 +25,11 @@ async function getHeading(p: import('@playwright/test').Page) {
   return ((await p.locator('h1').first().textContent({ timeout: 5000 }).catch(() => '')) || '').trim();
 }
 
+// consumerDebts:true makes navigateFinancialAffairs pick "Primarily consumer
+// debts" on the single Form 101 debt-classification radio, which is what now
+// derives non_consumer_debts=False (the consumer path this probe exercises).
+const SCN = { ...SIMPLE_SINGLE, meansTest: { consumerDebts: true } };
+
 async function reachMeansTestExemptions(page: import('@playwright/test').Page) {
   await navigateToDebtorPage(page, SIMPLE_SINGLE);
   await fillDebtorAndAdvance(page, SIMPLE_SINGLE.debtor);
@@ -38,7 +43,7 @@ async function reachMeansTestExemptions(page: import('@playwright/test').Page) {
   await navigateCommunityProperty(page);
   await navigateIncome(page, SIMPLE_SINGLE);
   await navigateExpenses(page, SIMPLE_SINGLE.rentExpense, 0);
-  await navigateFinancialAffairs(page, SIMPLE_SINGLE);
+  await navigateFinancialAffairs(page, SCN);
   await navigateReporting(page);
   await navigatePersonalLeases(page);
 
@@ -59,9 +64,9 @@ test('means_test_exemptions advances under masked Continue with all-No (consumer
   const heading = await getHeading(page);
   expect(heading.toLowerCase()).toContain('identify any exemptions from presumption of abuse');
 
-  // Click No on each of the 3 yesnoradios via label
+  // Click No on each of the yesnoradios (veteran, reservist) via label
   await page.evaluate(() => {
-    const names = ['monthly_income.non_consumer_debts', 'monthly_income.disabled_veteran', 'monthly_income.reservists'];
+    const names = ['monthly_income.disabled_veteran', 'monthly_income.reservists'];
     names.forEach((name) => {
       // docassemble b64: standard base64, no padding
       const b64 = btoa(name).replace(/=+$/, '');
@@ -88,7 +93,7 @@ test('means_test_exemptions advances under STRICT Continue with all-No (consumer
   expect(heading.toLowerCase()).toContain('identify any exemptions from presumption of abuse');
 
   await page.evaluate(() => {
-    const names = ['monthly_income.non_consumer_debts', 'monthly_income.disabled_veteran', 'monthly_income.reservists'];
+    const names = ['monthly_income.disabled_veteran', 'monthly_income.reservists'];
     names.forEach((name) => {
       // docassemble b64: standard base64, no padding
       const b64 = btoa(name).replace(/=+$/, '');


### PR DESCRIPTION
Works through Roxanne's 7/13 feedback email (three items).

## 1. "Software said I couldn't claim NE exemptions" (2-year domicile)

There is no logic bug — the warning only appears after answering **No** to the Schedule C question "Have you lived in [state] for at least the last 2 years?" Roxanne almost certainly read it as a question about her *address* (she mentioned the SOFA prior-address questions). Fixes:

- The question now states it's about the **state**, not any one address — moving between homes within the state still counts, and most people answer Yes.
- The warning screen now opens with **"Answered by mistake? Click Back — you can still claim [state] exemptions."** and only then explains the 730-day rule (§ 522(b)(3)(A) citation kept — `domicile-730-day-warning.spec.ts` asserts on it).

## 2. Secured creditors screen description

Added descriptions to the Schedule D gate and claim screens — **but with the opposite content of Roxanne's suggestion.** She assumed the home mortgage and car creditor were "already listed." They are **not**: the earlier property screens only capture *how much* is owed, never the lender. Auto-suppressing mortgage/vehicle lenders here would ship a Schedule D missing the mortgage creditor. The new text explicitly says to include them:

> **Include your home mortgage and vehicle loan lenders here.** Earlier questions about your home and vehicles only asked *how much* you owe — the lenders themselves have not been listed yet.

⚠️ Worth explaining this distinction in the reply to Roxanne — her mental model ("already listed") is exactly the one that would produce an incomplete Schedule D.

## 3. Debt classification asked once (was three times)

The same fact was asked three separate times:
1. Form 101 Part 6 — "What kind of debts do you have?" (consumer/business/other — her screenshot)
2. SOFA/107 q6 — "Are your debts primarily consumer debts?" (yes/no)
3. 122A means test — "Are your debts primarily non-consumer?" (yes/no radio)

Now the Form 101 radio is the **single source of truth**, asked once at the point the SOFA question used to appear, with Roxanne's suggested guidance ("for most people the answer is Primarily consumer debts … choose business only if most of what you owe comes from running a business", § 101(8) definition). 107 and 122A **derive** from it in the mandatory block — so besides asking once, the three official forms can no longer contradict each other. The veteran/reservist means-test questions are unchanged, and the 122A screen notes the debt kind was already answered.

Flow safety: the removed question blocks are gone (not shadowed), keeping one generator per variable; derivations are plain mandatory-block assignments; `disabled_veteran`/`reservists` are sought explicitly so the exemption screen still appears for business-debt filers.

## Test changes

`navigateFinancialAffairs` answers the debt-kind radio (consumer when `scenario.meansTest.consumerDebts`, business otherwise — preserving the means-test short-circuit default); `navigateReporting`/`navigateMeansTest` no longer answer it. Specs that drove the removed 122A radio updated; yaml-question-ids snapshot regenerated for the removed SOFA block.

## Verification

- All lint gates clean: flow-gaps, pdf-fields, caps-sync, test-completeness, selectors, yaml-ids.
- `interview_dependency_check` — no new question+code dual definers (the derived vars are code-only now).
- Playwright vs local container deploy, all through full PDF assembly:
  - domicile-730-day-warning, probe-means-test-consumer (×2), means-test-nonfiling-spouse, scenario-simple-single (19 PDFs + 22 cross-form invariants) — 5/5
  - feedback-fixes-verify (joint, consumer means test), means-test-social-security, scenario-joint-couple (19 PDFs) — 3/3
- tsc: 35 pre-existing errors on main, none introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Wga83AnCNF4t9m3UDbkom