### PR TITLE
Add cron-driven feedback-loop tooling

### DIFF
--- a/.claude/commands/process-feedback.md
+++ b/.claude/commands/process-feedback.md
@@ -1,0 +1,104 @@
+---
+description: Process new UAT feedback email end-to-end (triage → fix → test → PR → deploy to UAT → draft reply)
+---
+
+Process new BankruptcyClinic tester-feedback email. This runs headless from
+cron, so never wait for user input; when blocked, log why and exit cleanly.
+
+# Hard guardrails (never violate)
+
+- **Never send email.** Replies are written as local draft FILES for Alex to
+  review and paste into Outlook (the M365 connector is read-only for this
+  account — ALL Outlook write tools, including create_draft /
+  create_reply_draft / label tools, return permission_error; do not attempt
+  them). Reply files are plain text: no markdown, no blockquotes, no formatting.
+- **Never merge a PR, never push to or commit on main.** Branch + PR only; Alex
+  merges in the web portal.
+- **Never deploy if tests fail.** A failing fix gets a pushed WIP branch and a
+  draft PR (`gh pr create --draft`), no UAT deploy, no "it's fixed" reply draft.
+- **Legal/statutory questions are attorney territory.** If feedback needs a
+  substantive-law decision (exemption amounts, citations, form interpretation),
+  do NOT change code — draft a reply saying it's been flagged for attorney
+  review, and say so in the run log.
+
+# Preconditions (check first, abort politely if unmet)
+
+1. `git status --porcelain -- . ':!node_modules'` must be clean. If dirty, Alex
+   is likely mid-work: log "working tree dirty, skipping run" and exit.
+2. Record the current branch; switch back to it at the end of the run.
+3. `curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/` must be 200
+   (local docassemble container up, needed for test deploys). If not, log and exit.
+
+# Steps
+
+1. **Find unprocessed feedback.** Use `outlook_email_search` for inbox messages
+   from the last 14 days. Feedback = messages about the bankruptcy
+   interview/forms/clinic app (testers include Roxanne, McKenna, William/ERLS —
+   but judge by content, not just sender). Skip any message whose id is already
+   in the state file `~/.config/bankruptcyclinic/feedback-processed.txt`
+   (check with `grep -F '<messageId>' <state file>`). Do NOT use Outlook
+   labels/categories — the connector's label-write tools return
+   permission_error for this account. If nothing new: log "no new feedback"
+   and exit — that's the normal case.
+
+2. **Triage each feedback email** (process at most 2 per run, oldest first) into:
+   - (a) legitimate bug/UX issue → code fix
+   - (b) tester misunderstanding or the app is actually correct → reply only,
+     explaining kindly and precisely (this happens: verify the claim against the
+     actual YAML/flow before assuming the tester is right — e.g. Roxanne's
+     July "already listed" assumption was inverted)
+   - (c) needs attorney/legal sign-off → reply only, flag for attorney
+
+3. **For (a) — implement the fix:**
+   - `git fetch origin && git switch -c feedback/<short-slug> origin/main`
+   - Follow CLAUDE.md interview-flow rules (deterministic seeking, show-if
+     mirroring, one generator per variable, etc.).
+   - If interview flow/order changed, mirror it in `tests/navigation-helpers.ts`.
+   - Add or extend a Playwright spec that drives the ACTUAL failing branch the
+     tester hit (not the happy path) and runs through PDF assembly
+     (`finishAndAssertAllPdfs`).
+
+4. **Test:**
+   - `npm run lint` (all burn-down gates must pass).
+   - `./deploy.sh` to the local container, then run the new/affected specs:
+     `BASE_URL=http://localhost:8080 npx playwright test <specs> --workers=1 --reporter=line`
+   - Any failure → guardrail above (draft PR, no deploy, no fixed-reply).
+
+5. **Ship for re-verification:**
+   - Commit (end message with the Claude Code co-author trailer), push the branch.
+   - `gh pr create` with a summary of the feedback, the fix, and test evidence.
+   - `./scripts/deploy-prod.sh` to deploy to https://docassemble2.metatheria.solutions
+     so the tester can re-check.
+
+6. **Draft the reply as a file:** write plain text to
+   `~/bankruptcyclinic-replies/<YYYY-MM-DD>-<short-slug>.txt` with a header
+   block (`To:`, `Subject:` — Re: the original subject — and the original
+   message's webLink so Alex can open the thread in one click), a blank line,
+   then the reply body: thank them, state in one or two sentences what was
+   wrong and what changed (or why no change / attorney flag), note it's live
+   on the test site, and ask them to re-verify. Plain text only; Alex
+   copies it into Outlook and sends.
+
+7. **Mark processed:** append a line to
+   `~/.config/bankruptcyclinic/feedback-processed.txt`:
+   `<messageId><TAB><received date><TAB><sender><TAB><one-line outcome>`
+   (via `echo ... >> ...`). Do this for every triaged message, including
+   reply-only and already-handled ones.
+
+8. **Notify Alex if the run produced anything needing his attention** —
+   `./scripts/notify.sh "BC feedback loop" "<one-or-two-sentence summary>"`
+   whenever the run created a PR, deployed to UAT, wrote a reply file, or hit
+   a failure (test failure, deploy error). Include the PR URL and reply-file
+   path in the body. Do NOT notify on clean no-op runs (no new feedback,
+   skipped preconditions) — those stay log-only.
+
+9. **Log a run summary to stdout** (cron captures it): messages triaged,
+   branch/PR URLs, deploy result, reply files written. Then switch back to
+   the branch recorded in Preconditions.
+
+# Notes
+
+- If a `feedback/<slug>` branch or open PR already exists for a message's issue,
+  skip that message (a prior run has it in flight) — do not duplicate work.
+- Keep test scope targeted (lint gates + the specs touching the change), not the
+  full 136-spec suite; cron cadence is 30 minutes.

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ build/
 
 # Playwright
 /blob-report/
+
+# Claude Code local settings — contains machine-local permission rules; may hold secrets
+.claude/settings.local.json

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,6 @@
 
 set -e
 
-API_KEY="${DA_API_KEY:-M1L356QF6eplHGeaNNkF8QxDic126Wtv}"
 API_URL="${DA_API_URL:-http://localhost:8080}"
 PACKAGE_DIR="$(cd "$(dirname "$0")" && pwd)"
 DOCKER_CONTAINER="${DA_CONTAINER:-docassemble}"

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Deploy the package to the UAT/prod server (docassemble2.metatheria.solutions)
+# via the docassemble package API. For the LOCAL docker container use ./deploy.sh.
+#
+# Usage:
+#   ./scripts/deploy-prod.sh
+#
+# Credentials: sources ~/.config/bankruptcyclinic/prod-creds.env (DA_SERVER,
+# DA_API_KEY) unless DA_API_KEY is already in the environment. Never commit
+# credentials.
+#
+# Exit: 0 = installed and server healthy, non-zero otherwise.
+set -euo pipefail
+
+CREDS="${DA_PROD_CREDS:-$HOME/.config/bankruptcyclinic/prod-creds.env}"
+if [ -z "${DA_API_KEY:-}" ] && [ -f "$CREDS" ]; then
+  set -a; . "$CREDS"; set +a
+fi
+DA_SERVER="${DA_SERVER:-https://docassemble2.metatheria.solutions}"
+if [ -z "${DA_API_KEY:-}" ]; then
+  echo "ERROR: DA_API_KEY not set and $CREDS not found" >&2
+  exit 2
+fi
+
+PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ZIP=/tmp/da-package-prod.zip
+
+echo "Building package zip from $PACKAGE_DIR ..."
+cd "$(dirname "$PACKAGE_DIR")"
+rm -f "$ZIP"
+zip -r "$ZIP" \
+  "$(basename "$PACKAGE_DIR")/setup.py" \
+  "$(basename "$PACKAGE_DIR")/setup.cfg" \
+  "$(basename "$PACKAGE_DIR")/README.md" \
+  "$(basename "$PACKAGE_DIR")/LICENSE" \
+  "$(basename "$PACKAGE_DIR")/docassemble/" \
+  -x "*.pyc" -x "*__pycache__*" > /dev/null
+echo "Package zip: $(ls -lh "$ZIP" | awk '{print $5}')"
+
+echo "Uploading to $DA_SERVER/api/package ..."
+RESP=$(curl -fsS --max-time 120 -X POST "$DA_SERVER/api/package" \
+  -H "X-API-Key: $DA_API_KEY" \
+  -F "zip=@$ZIP")
+TASK_ID=$(printf '%s' "$RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("task_id",""))' 2>/dev/null || true)
+if [ -z "$TASK_ID" ]; then
+  echo "ERROR: no task_id in response: $RESP" >&2
+  exit 1
+fi
+echo "Install task: $TASK_ID"
+
+# Poll until the background install finishes (server restarts on success).
+for i in $(seq 1 60); do
+  sleep 5
+  STATUS=$(curl -fsS --max-time 20 \
+    -H "X-API-Key: $DA_API_KEY" \
+    "$DA_SERVER/api/package_update_status?task_id=$TASK_ID" 2>/dev/null || echo '{}')
+  STATE=$(printf '%s' "$STATUS" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("status","unknown"))' 2>/dev/null || echo unknown)
+  if [ "$STATE" = "completed" ]; then
+    OK=$(printf '%s' "$STATUS" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("ok"))' 2>/dev/null || echo None)
+    if [ "$OK" = "True" ]; then
+      echo "Install completed OK."
+      break
+    fi
+    echo "ERROR: install failed:" >&2
+    printf '%s\n' "$STATUS" >&2
+    exit 1
+  fi
+  echo "  ... $STATE ($((i * 5))s)"
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: install did not complete within 300s" >&2
+    exit 1
+  fi
+done
+
+echo "Waiting for interview to come back ..."
+URL="$DA_SERVER/interview?i=docassemble.BankruptcyClinic:data/questions/voluntary-petition.yml&new_session=1"
+for i in $(seq 1 30); do
+  sleep 4
+  HTTP=$(curl -s -o /dev/null --max-time 20 -w "%{http_code}" "$URL" 2>/dev/null || echo 000)
+  if [ "$HTTP" = "200" ]; then
+    echo "Server is healthy: $URL"
+    exit 0
+  fi
+done
+echo "ERROR: interview did not return 200 within timeout" >&2
+exit 1

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Push a notification via ntfy.sh (used by the feedback loop to flag runs
+# that produced work: a PR, a UAT deploy, a reply file, or a failure).
+#
+# Usage: ./scripts/notify.sh "Title" "Body text"
+#
+# The topic name acts as the only access control, so it is random and lives
+# outside git in ~/.config/bankruptcyclinic/notify.env (NTFY_TOPIC=...).
+# Subscribe on your phone/browser at https://ntfy.sh/<topic>.
+#
+# Exits 0 when unconfigured so a missing topic never breaks the caller.
+set -u
+
+CONF="${NTFY_CONF:-$HOME/.config/bankruptcyclinic/notify.env}"
+if [ -z "${NTFY_TOPIC:-}" ] && [ -f "$CONF" ]; then
+  set -a; . "$CONF"; set +a
+fi
+if [ -z "${NTFY_TOPIC:-}" ]; then
+  echo "notify.sh: NTFY_TOPIC not set ($CONF missing?) — skipping notification" >&2
+  exit 0
+fi
+
+TITLE="${1:-BankruptcyClinic}"
+BODY="${2:-(no message)}"
+
+curl -fsS --max-time 15 \
+  -H "Title: $TITLE" \
+  -H "Priority: ${NTFY_PRIORITY:-default}" \
+  -d "$BODY" \
+  "https://ntfy.sh/$NTFY_TOPIC" > /dev/null \
+  || { echo "notify.sh: ntfy.sh POST failed" >&2; exit 0; }
+echo "notified: $TITLE"


### PR DESCRIPTION
## What

Tooling for the automated UAT-feedback loop (cron + headless `claude -p "/process-feedback"`):

- **`.claude/commands/process-feedback.md`** — the loop body: triage Outlook feedback, fix on a `feedback/*` branch, run lint gates + targeted Playwright specs through PDF assembly, open a PR, deploy to the UAT server, write a plain-text reply file for human review. Hard guardrails: never send email, never merge, never deploy on test failure, attorney items get reply-only.
- **`scripts/deploy-prod.sh`** — package-API deploy to the UAT/prod server (upload zip, poll install status, health-check the interview URL).
- **`scripts/notify.sh`** — ntfy.sh push helper; the loop notifies only on runs that produce a PR, deploy, reply file, or failure.

## Secrets

None committed. `deploy-prod.sh` and `notify.sh` read all credentials/topics from `~/.config/bankruptcyclinic/` at runtime and error/skip cleanly when unset.

## Testing

- `deploy-prod.sh`: verified against the live package API read-only (auth + package listing); full deploy path not yet exercised.
- `notify.sh`: end-to-end test notification delivered.
- The loop itself: two live headless runs — one correctly skipped on a down container, one correctly triaged already-handled feedback (PR #144) as a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)