### PR TITLE
Fix prod dead-end: 107 builder loops clobbered the global `payment` object

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
@@ -2542,60 +2542,60 @@ code: |
 
 
   x=1
-  for payment in financial_affairs.consumer_debt_payments:
-    fin['creditor'+str(x)] = payment.creditor_name
-    fin['creditor_totalPaid'+str(x)] = currency(payment.total_amount)
-    fin['creditor_amountOwed'+str(x)] = currency(payment.amount_owed)
-    fin['creditor_isMortgage'+str(x)] = True if payment.payment_for == 'Mortgage' else False
-    fin['creditor_address'+str(x)] = payment.creditor_street
-    fin['creditor_paymentDates'+str(x)] = payment.paymentDates
-    fin['creditor_isCar'+str(x)] = True if payment.payment_for == 'Car' else False
-    fin['creditor_isCC'+str(x)] = True if payment.payment_for == 'Credit Card' else False
-    fin['creditor_isLoan'+str(x)] = True if payment.payment_for == 'Loan repayment' else False
-    fin['creditor_isVendor'+str(x)] = True if payment.payment_for == 'Suppliers or vendors' else False
-    fin['creditor_city'+str(x)] = payment.creditor_city
-    fin['creditor_state'+str(x)] = payment.creditor_state
-    fin['creditor_zip'+str(x)] = payment.creditor_zip
-    fin['creditor_isOther'+str(x)] = True if payment.payment_for == 'Other' else False
-    fin['creditor_other'+str(x)] = payment.payment_for
+  for pmt in financial_affairs.consumer_debt_payments:
+    fin['creditor'+str(x)] = pmt.creditor_name
+    fin['creditor_totalPaid'+str(x)] = currency(pmt.total_amount)
+    fin['creditor_amountOwed'+str(x)] = currency(pmt.amount_owed)
+    fin['creditor_isMortgage'+str(x)] = True if pmt.payment_for == 'Mortgage' else False
+    fin['creditor_address'+str(x)] = pmt.creditor_street
+    fin['creditor_paymentDates'+str(x)] = pmt.paymentDates
+    fin['creditor_isCar'+str(x)] = True if pmt.payment_for == 'Car' else False
+    fin['creditor_isCC'+str(x)] = True if pmt.payment_for == 'Credit Card' else False
+    fin['creditor_isLoan'+str(x)] = True if pmt.payment_for == 'Loan repayment' else False
+    fin['creditor_isVendor'+str(x)] = True if pmt.payment_for == 'Suppliers or vendors' else False
+    fin['creditor_city'+str(x)] = pmt.creditor_city
+    fin['creditor_state'+str(x)] = pmt.creditor_state
+    fin['creditor_zip'+str(x)] = pmt.creditor_zip
+    fin['creditor_isOther'+str(x)] = True if pmt.payment_for == 'Other' else False
+    fin['creditor_other'+str(x)] = pmt.payment_for
 
     x += 1
 
   fin['noInsiderPayments'] = True if financial_affairs.insider_payments.there_are_any == False else False
   fin['yesInsiderPayments'] = True if financial_affairs.insider_payments.there_are_any == True else False
   x = 1
-  for payment in financial_affairs.insider_payments:
-    fin['insider'+str(x)] = payment.insider_name
-    fin['insider_address'+str(x)] = payment.street
-    fin['insider_city'+str(x)] = payment.city
-    fin['insider_state'+str(x)] = payment.state
-    fin['insider_zip'+str(x)] = payment.zip
-    fin['insider_paymentDates'+str(x)] = payment.paymentDates
-    fin['insider_totalPaid'+str(x)] = currency(payment.total_amount)
-    fin['insider_amountOwed'+str(x)] = currency(payment.amount_owed)
-    fin['insider_reason'+str(x)] = payment.reason
+  for pmt in financial_affairs.insider_payments:
+    fin['insider'+str(x)] = pmt.insider_name
+    fin['insider_address'+str(x)] = pmt.street
+    fin['insider_city'+str(x)] = pmt.city
+    fin['insider_state'+str(x)] = pmt.state
+    fin['insider_zip'+str(x)] = pmt.zip
+    fin['insider_paymentDates'+str(x)] = pmt.paymentDates
+    fin['insider_totalPaid'+str(x)] = currency(pmt.total_amount)
+    fin['insider_amountOwed'+str(x)] = currency(pmt.amount_owed)
+    fin['insider_reason'+str(x)] = pmt.reason
 
     x += 1
 
   fin['noBenefitPayments'] = True if financial_affairs.insider_benefits.there_are_any == False else False
   fin['yesBenefitPayments'] = True if financial_affairs.insider_benefits.there_are_any == True else False
   x = 1
-  for payment in financial_affairs.insider_benefits:
-    fin['benefit'+str(x)] = payment.insider_name
-    fin['benefit_address'+str(x)] = payment.street
-    fin['benefit_city'+str(x)] = payment.city
-    fin['benefit_state'+str(x)] = payment.state
-    fin['benefit_zip'+str(x)] = payment.zip
-    fin['benefit_payment1_'+str(x)] = format_date(payment.payment_date_1, format='MM/dd/yyyy')
-    fin['benefit_payment2_'+str(x)] = format_date(payment.payment_date_2, format='MM/dd/yyyy') if getattr(payment, 'payment_date_2', None) else None
-    fin['benefit_payment3_'+str(x)] = format_date(payment.payment_date_3, format='MM/dd/yyyy') if getattr(payment, 'payment_date_3', None) else None
+  for pmt in financial_affairs.insider_benefits:
+    fin['benefit'+str(x)] = pmt.insider_name
+    fin['benefit_address'+str(x)] = pmt.street
+    fin['benefit_city'+str(x)] = pmt.city
+    fin['benefit_state'+str(x)] = pmt.state
+    fin['benefit_zip'+str(x)] = pmt.zip
+    fin['benefit_payment1_'+str(x)] = format_date(pmt.payment_date_1, format='MM/dd/yyyy')
+    fin['benefit_payment2_'+str(x)] = format_date(pmt.payment_date_2, format='MM/dd/yyyy') if getattr(pmt, 'payment_date_2', None) else None
+    fin['benefit_payment3_'+str(x)] = format_date(pmt.payment_date_3, format='MM/dd/yyyy') if getattr(pmt, 'payment_date_3', None) else None
     for _dn in [4, 5, 6]:
-      _pd = getattr(payment, 'payment_date_' + str(_dn), None)
+      _pd = getattr(pmt, 'payment_date_' + str(_dn), None)
       if _pd:
         fin['benefit_payment'+str(_dn)+'_'+str(x)] = format_date(_pd, format='MM/dd/yyyy')
-    fin['benefit_totalPaid'+str(x)] = currency(payment.total_amount)
-    fin['benefit_amountOwed'+str(x)] = currency(payment.amount_owed)
-    fin['benefit_reason'+str(x)] = payment.reason
+    fin['benefit_totalPaid'+str(x)] = currency(pmt.total_amount)
+    fin['benefit_amountOwed'+str(x)] = currency(pmt.amount_owed)
+    fin['benefit_reason'+str(x)] = pmt.reason
 
     x += 1
 
@@ -2695,20 +2695,20 @@ code: |
   fin['noConsulting'] = True if financial_affairs.bankruptcy_payments.there_are_any == False else False
   fin['yesConsulting'] = True if financial_affairs.bankruptcy_payments.there_are_any == True else False
   x = 1
-  for payment in financial_affairs.bankruptcy_payments:
-    fin['consult_name'+str(x)] = payment.name
-    fin['consult_address'+str(x)] = payment.street
-    fin['consult_city'+str(x)] = payment.city
-    fin['consult_state'+str(x)] = payment.state
-    fin['consult_zip'+str(x)] = payment.zip
-    fin['consult_email'+str(x)] = payment.email_or_website
-    fin['consult_date1-'+str(x)] = format_date(payment.date_1, format='MM/dd/yyyy')
-    fin['consult_amt1-'+str(x)] = currency(payment.value_1)
-    if payment.value_2 > 0:
-      fin['consult_date2-'+str(x)] = format_date(payment.date_2, format='MM/dd/yyyy') if getattr(payment, 'date_2', None) else None
-      fin['consult_amt2-'+str(x)] = currency(payment.value_2)
-    fin['consult_who'+str(x)] = payment.payment_person
-    fin['consult_describe'+str(x)] = payment.property_description
+  for pmt in financial_affairs.bankruptcy_payments:
+    fin['consult_name'+str(x)] = pmt.name
+    fin['consult_address'+str(x)] = pmt.street
+    fin['consult_city'+str(x)] = pmt.city
+    fin['consult_state'+str(x)] = pmt.state
+    fin['consult_zip'+str(x)] = pmt.zip
+    fin['consult_email'+str(x)] = pmt.email_or_website
+    fin['consult_date1-'+str(x)] = format_date(pmt.date_1, format='MM/dd/yyyy')
+    fin['consult_amt1-'+str(x)] = currency(pmt.value_1)
+    if pmt.value_2 > 0:
+      fin['consult_date2-'+str(x)] = format_date(pmt.date_2, format='MM/dd/yyyy') if getattr(pmt, 'date_2', None) else None
+      fin['consult_amt2-'+str(x)] = currency(pmt.value_2)
+    fin['consult_who'+str(x)] = pmt.payment_person
+    fin['consult_describe'+str(x)] = pmt.property_description
 
     x += 1
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "lint:test-complete": "./scripts/lint-test-completeness.sh",
     "lint:caps-sync": "python3 scripts/lint_caps_sync.py",
     "lint:pdf-fields": "./scripts/lint-pdf-fields.sh",
-    "lint": "npm run lint:selectors && npm run lint:yaml-ids && npm run lint:flow && npm run lint:test-complete && npm run lint:caps-sync && npm run lint:pdf-fields",
+    "lint:namespace-clobber": "python3 scripts/lint_namespace_clobber.py",
+    "lint": "npm run lint:selectors && npm run lint:yaml-ids && npm run lint:flow && npm run lint:test-complete && npm run lint:caps-sync && npm run lint:pdf-fields && npm run lint:namespace-clobber",
     "graph": "python3 scripts/interview_graph.py",
     "graph:map": "python3 scripts/interview_graph.py --map",
-    "pretest": "npm run lint:selectors && npm run lint:yaml-ids && npm run lint:flow && npm run lint:test-complete && npm run lint:caps-sync && npm run lint:pdf-fields"
+    "pretest": "npm run lint:selectors && npm run lint:yaml-ids && npm run lint:flow && npm run lint:test-complete && npm run lint:caps-sync && npm run lint:pdf-fields && npm run lint:namespace-clobber"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",

--- a/scripts/lint_namespace_clobber.py
+++ b/scripts/lint_namespace_clobber.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Gate: code blocks must not clobber interview-global object names.
+
+docassemble `exec`s a `code:` block against the interview's variable
+namespace (the user dict). There are no function scopes, so EVERY binding a
+code block creates is a WRITE to a global interview variable — including
+`for` loop targets, comprehension targets, `with ... as` targets, and walrus
+assignments.
+
+That makes an innocuous-looking loop a silent overwrite:
+
+    for payment in financial_affairs.consumer_debt_payments:   # BUG
+        fin['creditor'] = payment.creditor_name
+
+`payment` is the Form 103A installment-application DAObject. After this loop
+runs, the global `payment` IS a SOFA list item, so the 103A builder's
+`payment.payment_on_petition` resolves against the wrong object and there is
+no question to define it. Prod symptom (2026-07-30):
+
+    DAErrorMissingVariable: there was a reference to a variable
+    'financial_affairs.consumer_debt_payments[0].payment_on_petition'
+
+...and because the `mandatory` block re-runs on every screen, the filer is
+dead-ended for the rest of the session.
+
+This check parses each `code:` block's Python with `ast` and reports any
+binding whose name collides with a name declared in an `objects:` block.
+
+Exit status: 0 = clean, 1 = new clobber found (see the baseline file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import glob
+import os
+import sys
+
+import yaml
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+QUESTIONS = os.path.join(ROOT, "docassemble", "BankruptcyClinic", "data", "questions")
+BASELINE = os.path.join(HERE, "namespace-clobber-baseline.txt")
+
+# False-clean guard: the interview currently has ~136 code blocks. If we parse
+# far fewer, the checker did not really run.
+MIN_CODE_BLOCKS = 100
+
+
+def interview_globals(files: list[str]) -> set[str]:
+    """Top-level names declared in any `objects:` block."""
+    names: set[str] = set()
+    for path in files:
+        try:
+            docs = list(yaml.safe_load_all(open(path, encoding="utf-8")))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or "objects" not in doc:
+                continue
+            entries = doc["objects"]
+            if not isinstance(entries, list):
+                entries = [entries]
+            for entry in entries:
+                if isinstance(entry, dict):
+                    for key in entry:
+                        names.add(str(key).split(".")[0].split("[")[0])
+    return names
+
+
+def code_blocks(path: str):
+    """Yield (first_code_line, code_text) for every `code:` block in a file.
+
+    Uses the YAML composer rather than text splitting so document separators and
+    block scalars are handled by the parser, and so each `code:` value carries a
+    real source mark. `first_code_line` is the 1-indexed file line of the
+    block's first line of Python, making `first_code_line + node.lineno - 1` the
+    exact file line of an AST node.
+    """
+    text = open(path, encoding="utf-8").read()
+    try:
+        docs = list(yaml.compose_all(text))
+    except yaml.YAMLError:
+        return
+
+    for doc in docs:
+        if not isinstance(doc, yaml.MappingNode):
+            continue
+        for key, value in doc.value:
+            if not (isinstance(key, yaml.ScalarNode) and key.value == "code"):
+                continue
+            if not isinstance(value, yaml.ScalarNode):
+                continue
+            # For a literal block scalar (`code: |`), start_mark.line is the
+            # line of the `|` indicator, so the Python starts on the next line.
+            yield value.start_mark.line + 2, value.value
+
+
+def bound_names(code: str):
+    """Yield (name, lineno, kind) for every name a code block binds."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return
+
+    def targets(node, kind):
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
+                yield sub.id, sub.lineno, kind
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.For, ast.AsyncFor)):
+            yield from targets(node.target, "for-loop target")
+        elif isinstance(node, ast.comprehension):
+            yield from targets(node.target, "comprehension target")
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    yield from targets(item.optional_vars, "with-as target")
+        elif isinstance(node, ast.NamedExpr):
+            yield from targets(node.target, "walrus assignment")
+
+
+def load_baseline() -> set[str]:
+    if not os.path.exists(BASELINE):
+        return set()
+    out = set()
+    for line in open(BASELINE, encoding="utf-8"):
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.add(line)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite the baseline to the current findings (tighten after a fix)",
+    )
+    args = ap.parse_args()
+
+    files = sorted(glob.glob(os.path.join(QUESTIONS, "*.yml")))
+    if not files:
+        print(f"lint:namespace-clobber: no YAML found under {QUESTIONS}", file=sys.stderr)
+        return 1
+
+    reserved = interview_globals(files)
+    findings: list[tuple[str, str]] = []  # (key, human-readable line)
+    blocks_seen = 0
+
+    for path in files:
+        rel = os.path.relpath(path, ROOT)
+        for block_line, code in code_blocks(path):
+            blocks_seen += 1
+            for name, lineno, kind in bound_names(code):
+                if name not in reserved:
+                    continue
+                key = f"{rel}:{name}:{kind}"
+                where = f"line {block_line + lineno - 1}"
+                findings.append((key, f"{rel} {where}: {kind} `{name}` overwrites the global object `{name}`"))
+
+    findings.sort()
+    keys = {k for k, _ in findings}
+
+    # A gate that silently analysed nothing reports "clean" — the worst failure
+    # mode for a burn-down gate. Refuse to pass on an empty parse.
+    if blocks_seen < MIN_CODE_BLOCKS:
+        print(
+            f"lint:namespace-clobber: FAIL — only parsed {blocks_seen} code block(s) "
+            f"across {len(files)} file(s), expected >= {MIN_CODE_BLOCKS}. The checker "
+            "probably did not run (YAML parse failure or moved question files).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.update:
+        with open(BASELINE, "w", encoding="utf-8") as fh:
+            fh.write("# Known code-block writes to interview-global object names.\n")
+            fh.write("# Regenerate with: python3 scripts/lint_namespace_clobber.py --update\n")
+            for key in sorted(keys):
+                fh.write(key + "\n")
+        print(f"lint:namespace-clobber: baseline updated ({len(keys)} entries)")
+        return 0
+
+    baseline = load_baseline()
+    new = [(k, msg) for k, msg in findings if k not in baseline]
+
+    if new:
+        print("lint:namespace-clobber: FAIL — new code-block write(s) to a global object name:\n")
+        for _, msg in new:
+            print(f"  {msg}")
+        print(
+            "\nA docassemble `code:` block has no function scope: a loop/comprehension\n"
+            "target is a WRITE to the interview variable of that name. Rename the local\n"
+            "(e.g. `for pmt in ...`), or run --update if this is genuinely intended."
+        )
+        return 1
+
+    stale = sorted(baseline - keys)
+    print(f"lint:namespace-clobber: OK ({blocks_seen} code blocks, {len(keys)} known, 0 new)")
+    if stale:
+        print(f"  {len(stale)} baseline entry(ies) now fixed — tighten with --update:")
+        for key in stale:
+            print(f"    {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mutation-test-gates.sh
+++ b/scripts/mutation-test-gates.sh
@@ -62,6 +62,13 @@ f="$Q/106H-question-blocks.yml"
 sed -i "0,/^id: codebtors_any_exist/s//id: codebtors_any_exist_MUTATED/" "$f"
 check "lint:yaml-ids (id snapshot)" "$f" ./scripts/yaml-question-ids-snapshot.sh
 
+# 6) Namespace clobber: make a code-block loop target shadow a global object
+#    (the prod DAErrorMissingVariable of 2026-07-30 — `for payment in ...`
+#    overwrote the Form 103A `payment` object).
+f="$Q/107-question-blocks.yml"
+sed -i "0,/for pmt in financial_affairs.consumer_debt_payments:/s//for payment in financial_affairs.consumer_debt_payments:/" "$f"
+check "lint:namespace-clobber" "$f" python3 scripts/lint_namespace_clobber.py
+
 echo ""
 if [ "$FAILS" -eq 0 ]; then
   echo "✅ all gates have teeth — every injected bug was caught"

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -171,6 +171,35 @@ export interface MeansTestOptions {
   medianIncome?: string;
 }
 
+export interface ConsumerDebtPaymentData {
+  name: string;
+  street: string;
+  city: string;
+  /** Full state name, as shown in the dropdown (e.g. 'Nebraska'). */
+  state: string;
+  zip: string;
+  paymentDates: string;
+  totalAmount: string;
+  amountOwed: string;
+  /** One of: Mortgage, Car, Credit Card, Loan repayment, Suppliers or vendors, Other. */
+  paymentFor: string;
+}
+
+export interface CaseDetailsOptions {
+  /**
+   * Which Form 101 fee-payment option to choose. 'full' (default) is the happy
+   * path; 'installments' drives the Form 103A application, which is the branch
+   * that defines the global `payment` object.
+   */
+  feePayment?: 'full' | 'installments';
+  /** Installments only: make a first payment when filing (Form 103A line 1a). */
+  paymentOnPetition?: boolean;
+  /** Installments only: amount paid when filing, when paymentOnPetition. */
+  initialPaymentAmount?: string;
+  /** Installments only: the proposed installment schedule (≥1 required). */
+  installments?: Array<{ amount: string; date: string }>;
+}
+
 export interface TestScenario {
   name: string;
   district: string;
@@ -187,6 +216,13 @@ export interface TestScenario {
   expenses?: ExpenseData;
   hasCodebtor?: boolean;
   hasContracts?: boolean;
+  /**
+   * SOFA q6 consumer-creditor payments (last 90 days). Omit/empty for the happy
+   * path "No"; supply entries to drive the 107 builder's payment loops.
+   */
+  consumerDebtPayments?: ConsumerDebtPaymentData[];
+  /** Form 101 fee-payment branch + Form 103A installment details. */
+  caseDetails?: CaseDetailsOptions;
   dependents?: number;
   meansTest?: MeansTestOptions;
 }

--- a/tests/installments-with-sofa-payments.spec.ts
+++ b/tests/installments-with-sofa-payments.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression: prod crash `DAErrorMissingVariable: ... reference to a variable
+ * 'financial_affairs.consumer_debt_payments[0].payment_on_petition'`
+ * (docassemble2 error mail, 2026-07-30 02:53 + 02:57 UTC).
+ *
+ * Root cause: docassemble `exec`s code blocks against the interview namespace,
+ * so a `for` loop target in a code block is a WRITE to that global name. The
+ * 107 builder looped `for payment in financial_affairs.consumer_debt_payments:`
+ * (and over insider_payments / insider_benefits / bankruptcy_payments), which
+ * rebound the GLOBAL `payment` DAObject — the Form 103A installment
+ * application — to a SOFA list item. The 103A builder then read
+ * `payment.payment_on_petition`, which resolved against the wrong object and
+ * had no question to define it. Dead end: the mandatory block re-runs every
+ * screen, so once 107 had assembled the filer could not proceed at all.
+ *
+ * Trigger: choose "pay the fee in installments" (Form 103A defines `payment`)
+ * AND have at least one SOFA payment entry (a non-empty list is what makes the
+ * loop body execute and clobber the name). Both happy-path helper defaults —
+ * "pay the entire fee" and SOFA all-No — hid this, so this spec drives the
+ * actual failing branch and runs through to PDF assembly.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE, TestScenario } from './fixtures';
+import { runFullInterview } from './navigation-helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+
+const SCN: TestScenario = {
+  ...SIMPLE_SINGLE,
+  name: 'installments-with-sofa-payments',
+  // Non-empty SOFA q6 list → the 107 builder's payment loop actually runs.
+  consumerDebtPayments: [
+    {
+      name: 'Cornhusker Credit Union',
+      street: '1200 O St',
+      city: 'Lincoln',
+      state: 'Nebraska',
+      zip: '68508',
+      paymentDates: '06/02/2026 $620.00\n07/02/2026 $620.00',
+      totalAmount: '1240',
+      amountOwed: '4300',
+      paymentFor: 'Loan repayment',
+    },
+  ],
+  // Installments branch → the global `payment` object (Form 103A) exists and is
+  // read by the 103A builder at assembly.
+  caseDetails: {
+    feePayment: 'installments',
+    paymentOnPetition: true,
+    initialPaymentAmount: '78',
+    // ISO format — the collect page renders <input type="date">.
+    installments: [{ amount: '260', date: '2026-09-15' }],
+  },
+};
+
+test.setTimeout(600_000);
+
+test('installments + SOFA consumer-debt payments assembles (global `payment` not clobbered by 107 loops)', async ({
+  page,
+}) => {
+  await runFullInterview(page, SCN);
+
+  // The crash surfaced as an error page while assembling 103A. Assert the
+  // interview reached assembly and produced the forms, including 103A.
+  const pdfs = await finishAndAssertAllPdfs(page, { mustInclude: ['101', '103', '106', '107', '122'] });
+
+  const names = pdfs.map((p) => p.name.toLowerCase()).join(' | ');
+  expect(names, 'Form 103A (installment application) did not assemble').toContain('103');
+});

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -27,7 +27,7 @@ import {
   setCheckbox,
   handleAnotherPage,
 } from './helpers';
-import { TestScenario, MeansTestOptions, DebtorProfile, RealPropertyData, VehicleData, DepositData } from './fixtures';
+import { TestScenario, MeansTestOptions, CaseDetailsOptions, DebtorProfile, RealPropertyData, VehicleData, DepositData } from './fixtures';
 
 // ════════════════════════════════════════════════════════════════════
 //  INTRO → DEBTOR PAGE
@@ -596,9 +596,44 @@ export async function navigateFinancialAffairs(page: Page, scenario: TestScenari
   await clickContinue(page);
   await waitForDaPageLoad(page);
 
-  // All list-gathers → No
+  // SOFA q6 — consumer-creditor payments in the last 90 days. Default No (the
+  // happy path), but a scenario can add real entries: the 107 builder loops
+  // over this list, and a non-empty list is what exposed the loop-variable
+  // clobber of the global `payment` object (prod DAErrorMissingVariable,
+  // 2026-07-30). Regression coverage needs at least one entry.
+  await waitForDaPageLoad(page);
+  const consumerPayments = scenario.consumerDebtPayments ?? [];
+  if (consumerPayments.length > 0) {
+    await clickYesNoButton(page, 'financial_affairs.consumer_debt_payments.there_are_any', true);
+    for (let i = 0; i < consumerPayments.length; i++) {
+      const p = consumerPayments[i];
+      // The per-item question renders its field names with a LITERAL `[i]`
+      // (the iterator is carried server-side), so don't substitute the index.
+      const v = (attr: string) => b64(`financial_affairs.consumer_debt_payments[i].${attr}`);
+      await waitForDaPageLoad(page);
+      await page.locator(`#${v('creditor_name')}`).fill(p.name);
+      await page.locator(`#${v('creditor_street')}`).fill(p.street);
+      await page.locator(`#${v('creditor_city')}`).fill(p.city);
+      await page.locator(`select#${v('creditor_state')}`).selectOption(p.state);
+      await page.locator(`#${v('creditor_zip')}`).fill(p.zip);
+      await page.locator(`#${v('paymentDates')}`).fill(p.paymentDates);
+      await page.locator(`#${v('total_amount')}`).fill(p.totalAmount);
+      await page.locator(`#${v('amount_owed')}`).fill(p.amountOwed);
+      await page.locator(`select#${v('payment_for')}`).selectOption(p.paymentFor);
+      await clickContinue(page);
+      await waitForDaPageLoad(page);
+      await clickYesNoButton(
+        page,
+        'financial_affairs.consumer_debt_payments.there_is_another',
+        i < consumerPayments.length - 1,
+      );
+    }
+  } else {
+    await clickYesNoButton(page, 'financial_affairs.consumer_debt_payments.there_are_any', false);
+  }
+
+  // Remaining list-gathers → No
   for (const varName of [
-    'financial_affairs.consumer_debt_payments.there_are_any',
     'financial_affairs.insider_payments.there_are_any',
     'financial_affairs.insider_benefits.there_are_any',
     'financial_affairs.lawsuits.there_are_any',
@@ -1153,7 +1188,7 @@ export async function navigateMeansTest(page: Page, opts: MeansTestOptions = {})
 //  CASE DETAILS
 // ════════════════════════════════════════════════════════════════════
 
-export async function navigateCaseDetails(page: Page) {
+export async function navigateCaseDetails(page: Page, opts: CaseDetailsOptions = {}) {
   await waitForDaPageLoad(page);
 
   // Handle unexpected debtor[1] income page that sometimes appears here
@@ -1187,7 +1222,11 @@ export async function navigateCaseDetails(page: Page) {
     console.log(`  [navigateCaseDetails] Next heading: "${caseH}"`);
   }
 
-  const payLabel = page.locator('label').filter({ hasText: 'I will pay the entire fee when I file my petition' });
+  const wantsInstallments = opts.feePayment === 'installments';
+  const payLabelText = wantsInstallments
+    ? 'I need to pay the fee in installments'
+    : 'I will pay the entire fee when I file my petition';
+  const payLabel = page.locator('label').filter({ hasText: payLabelText });
   await payLabel.click();
   await clickContinue(page);
 
@@ -1199,6 +1238,45 @@ export async function navigateCaseDetails(page: Page) {
 
   await waitForDaPageLoad(page);
   await clickYesNoButton(page, 'case.rents_residence', false);
+
+  // Form 103A — only when paying in installments. This is the branch that
+  // defines the global `payment` object read by the 103A builder.
+  if (wantsInstallments) {
+    const paymentOnPetition = opts.paymentOnPetition ?? true;
+    const installments = opts.installments ?? [{ amount: '100', date: '2026-09-15' }];
+
+    // installment_payment_intro (continue button field)
+    await waitForDaPageLoad(page);
+    await clickNthByName(page, b64('installment_payment_intro'), 0);
+
+    // payment_method_details — payment_on_petition + (show-if) initial amount
+    await waitForDaPageLoad(page);
+    await selectYesNoRadio(page, 'payment.payment_on_petition', paymentOnPetition);
+    if (paymentOnPetition) {
+      // show-if'd fields render with a `_field_N` name, not the b64 variable
+      // name — target by label instead.
+      await page.getByLabel('Filing payment amount').fill(opts.initialPaymentAmount ?? '78');
+    }
+    await clickContinue(page);
+
+    // payment.payments — `list collect: True`, so every installment is filled
+    // on ONE page; item 0 is pre-rendered (minimum_number: 1) and further items
+    // are added with the collect page's "Add another" control.
+    await waitForDaPageLoad(page);
+    for (let i = 0; i < installments.length; i++) {
+      if (i > 0) {
+        await page.locator('a.dacollectadd:visible, button.dacollectadd:visible').first().click();
+        await page.locator(`#${b64(`payment.payments[${i}].amount`)}`).waitFor({ state: 'visible', timeout: 15000 });
+      }
+      await page.locator(`#${b64(`payment.payments[${i}].amount`)}`).fill(installments[i].amount);
+      await page.locator(`#${b64(`payment.payments[${i}].proposed_date`)}`).fill(installments[i].date);
+    }
+    await clickContinue(page);
+
+    // installment_payment_end (continue button field)
+    await waitForDaPageLoad(page);
+    await clickNthByName(page, b64('installment_payment_end'), 0);
+  }
 
   await waitForDaPageLoad(page);
   await clickNthByName(page, b64('case_final'), 0);
@@ -1694,7 +1772,7 @@ export async function runFullInterview(page: Page, scenario: TestScenario) {
   // Personal-property leases (form 108) now gather in their own step, after SOFA.
   log('personalLeases'); await navigatePersonalLeases(page);
   log('meansTest'); await navigateMeansTest(page, scenario.meansTest ?? {});
-  log('caseDetails'); await navigateCaseDetails(page);
+  log('caseDetails'); await navigateCaseDetails(page, scenario.caseDetails ?? {});
   log('business'); await navigateBusiness(page);
   log('hazardousProperty'); await navigateHazardousProperty(page);
   log('creditCounseling'); await navigateCreditCounseling(page, scenario);


### PR DESCRIPTION
## Prod crash (automated error mail, 2026-07-30 02:53 + 02:57 UTC)

```
DAErrorMissingVariable: there was a reference to a variable
'financial_affairs.consumer_debt_payments[0].payment_on_petition'
```

## Root cause

docassemble `exec`s `code:` blocks against the interview's variable namespace — there are no function scopes, so a `for` loop target is a WRITE to the interview global of that name. The Form 107 builder looped `for payment in financial_affairs.consumer_debt_payments:` (and over insider_payments / insider_benefits / bankruptcy_payments), rebinding the global `payment` DAObject — the Form 103A installment application — to a SOFA list item. The 103A builder then read `payment.payment_on_petition` off the wrong object, which has no question to define it. Because the mandatory block re-runs on every screen, the filer was permanently dead-ended.

Trigger: choose "pay the fee in installments" AND enter at least one SOFA payment — both hidden by the happy-path test defaults ("pay entire fee", SOFA all-No), which is why the suite never caught it.

## Changes

- **Fix:** rename the four loop targets `payment` → `pmt` in `107-question-blocks.yml` (verified `pmt` unused elsewhere).
- **New gate** `scripts/lint_namespace_clobber.py` (`npm run lint:namespace-clobber`, wired into `lint`/`pretest`): AST-scans every code block for `for`/comprehension/`with...as`/walrus bindings that shadow an `objects:`-declared global. Includes a min-code-blocks guard so a silent parse failure can't report clean. Mutation test #6 in `scripts/mutation-test-gates.sh` re-injects the exact prod bug and asserts the gate fails.
- **Test helpers:** SOFA q6 consumer-debt payments and the installments branch (Form 103A) are now scenario-drivable in `navigation-helpers.ts` / `fixtures.ts`.
- **Regression spec** `tests/installments-with-sofa-payments.spec.ts` drives the actual failing branch all the way through PDF assembly and asserts Form 103A assembles.

## Verification

- `npm run lint` — all 7 gates green (`lint:namespace-clobber: OK (136 code blocks, 0 known, 0 new)`)
- `./scripts/mutation-test-gates.sh` — 6/6 gates caught their injected bugs
- `npx playwright test installments-with-sofa-payments` — **1 passed (2.8m)**, reaches conclusion + all PDFs incl. 103

Note for the in-flight prod session: the saved session dict still holds the bad `payment` binding — the affected filer recovers by clicking **Back** one step after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUZ94ArnHybSn2AJVpjTnX