### PR TITLE
Roxanne UAT (July 2026, batch 4): installment 90-day cap, counseling radio, nav/property-summary fix, DOJ tables

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -937,6 +937,9 @@ subquestion: |
 fields:
 
  - Credit counseling status: debtor[i].counseling.counseling_type
+   # Radio, not dropdown: these long labels cannot wrap inside a <select>, so
+   # the menu ran off the screen (Roxanne UAT 2026-07-29).
+   input type: radio
    choices:
      - I received a briefing from an approved credit counseling agency within the 180 days before I filed this bankruptcy petition, and I received a certificate of completion.: 1
      - I received a briefing from an approved credit counseling agency within the 180 days before I filed this bankruptcy petition, but I do not have a certificate of completion.: 2

--- a/docassemble/BankruptcyClinic/data/questions/103A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/103A-question-blocks.yml
@@ -15,7 +15,7 @@ question: |
 subquestion: |
   You may apply to pay the filing fee in up to four installments. Fill in the amounts you propose to pay and the dates you plan to pay them. Be sure all dates are business days. Then add the payments you propose to pay.
   
-  You must propose to pay the entire fee no later than 120 days after you file this bankruptcy case. If the court approves your application, the court will set your final payment timetable.
+  You must propose to pay the entire fee within 90 days of the initial payment you make when you file this bankruptcy case. If the court approves your application, the court will set your final payment timetable.
 continue button field: installment_payment_intro
 ---
 id: installment_payment_summary_end
@@ -87,7 +87,7 @@ fields:
 id: payment_dates_add_another
 section: payment_installments
 question: |
-  Are there any more payment dates you'd like to add in the next 120 days?
+  Are there any more payment dates you'd like to add in the next 90 days?
 under: |
   % if payment.payment_on_petition:
     Payment on filing: ${payment.initial_payment_amount}
@@ -99,7 +99,7 @@ yesno: payment.payments.there_is_another
 id: payment_dates_any_exist
 section: payment_installments
 question: |
-  Do you have any payment dates you'd like to add in the next 120 days?
+  Do you have any payment dates you'd like to add in the next 90 days?
 yesno: payment.payments.there_are_any
 ---
 id: payment_details_individual
@@ -107,7 +107,10 @@ section: payment_installments
 question: |
   Fill in payment details.
 subquestion: |
-  You may apply to pay the filing fee in up to four installments. You must propose to pay the entire fee no later than 120 days after you file this bankruptcy case. If the court approves your application, the court will set your final payment timetable.
+  You may apply to pay the filing fee in up to four installments. Each proposed
+  payment date must be within 90 days of the day you file your case (the day
+  you pay the initial amount). If the court approves your application, the
+  court will set your final payment timetable.
 allowed to set:
   - payment.payments[i].complete
 fields:
@@ -115,6 +118,18 @@ fields:
     datatype: currency
   - On or before: payment.payments[i].proposed_date
     datatype: date
+    # Roxanne (Legal Aid NE) 2026-07-29: no installment may be proposed more
+    # than 90 days after the initial payment, which is made at filing; "today"
+    # stands in for the filing date since the application is prepared at
+    # filing time. Enforced with the HTML5 max attribute + client validator,
+    # NOT server-side validation: on a `list collect` page BOTH question-level
+    # `validation code` and per-field `validate` failures make the post-
+    # validation re-render infinite-loop on x.amount/x.complete → HTTP 501
+    # error page (verified empirically 2026-07-29/30).
+    max: ${ today().plus(days=90) }
+    validation messages:
+      date max: |
+        Each installment must be paid within 90 days of the initial payment you make when you file.
 under: |
   % if payment.payment_on_petition:
     Payment on filing: ${payment.initial_payment_amount}

--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -5147,12 +5147,12 @@ question: |
 review:
   - note: |
       <br>
-      ### Property Interests
+      ### Real Estate
       % if len(prop.interests) > 0:
         ${ prop_interests_table }
         ${ prop.interests.add_action() }
       % else:
-        No property interests currently listed.
+        No real estate currently listed.
         ${ prop.interests.add_action() }
       % endif
   - note: |

--- a/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
@@ -2,7 +2,10 @@ code: |
   prop_options = []
   if len(prop.interests) > 0:
     for interest in prop.interests:
-      prop_options.append(f'{interest.type} - {interest.street} {interest.city}, {interest.state}')
+      # `interest.type` is a checkboxes DADict — stringifying it front-loads a
+      # long type list and pushes the address out of the visible dropdown.
+      # Lead with "Real estate - <address>" instead (Roxanne UAT 2026-07-29).
+      prop_options.append(f'Real estate - {interest.street} {interest.city}, {interest.state}')
   if len(prop.ab_vehicles) > 0:
     for vehicle in prop.ab_vehicles:
       prop_options.append(f'Vehicle - {vehicle.make} {vehicle.model} {vehicle.year}')

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -908,22 +908,25 @@ code: |
 
 
   case.payment_method
-  if case.payment_method == '2':
+  if case.payment_method in ('2', '3'):
+    # Add the fee subsection under the *Case Details* nav entry. This used to
+    # assign to the_sections[3], but index 3 is "Property" (schedule_ab) —
+    # every installment/fee-waiver filer lost the Property link from the left
+    # menu (Roxanne UAT 2026-07-29: "the property summary ... just lists
+    # personal property"). Locate case_det by key instead of by position.
     new_sub_section = {}
-    new_sub_section["payment_installments"] = "Pay in Installments"
+    if case.payment_method == '2':
+      new_sub_section["payment_installments"] = "Pay in Installments"
+    else:
+      new_sub_section["waive_fee"] = "Waive Fees"
     new_main_section = {}
-    new_main_section["case_det"] = "Case Detail"
+    new_main_section["case_det"] = "Case Details"
     new_main_section["subsections"] = [new_sub_section]
     the_sections = nav.get_sections()
-    the_sections[3] = new_main_section
-  elif case.payment_method == '3':
-    new_sub_section = {}
-    new_sub_section["waive_fee"] = "Waive Fees"
-    new_main_section = {}
-    new_main_section["case_det"] = "Case Detail"
-    new_main_section["subsections"] = [new_sub_section]
-    the_sections = nav.get_sections()
-    the_sections[3] = new_main_section
+    for _nav_i, _nav_entry in enumerate(the_sections):
+      if isinstance(_nav_entry, dict) and "case_det" in _nav_entry:
+        the_sections[_nav_i] = new_main_section
+        break
   case.has_previous_bankruptcy
   if case.has_previous_bankruptcy:
     case.previous_bankruptcy.there_are_any = True
@@ -1476,12 +1479,12 @@ review:
 #Property
   - note: |
       <br>
-      ### Property Interests
+      ### Real Estate
       % if len(prop.interests) > 0:
         ${ prop_interests_table }
         ${ prop.interests.add_action() }
       % else:
-        No property interests currently listed.
+        No real estate currently listed.
         ${ prop.interests.add_action() }
       % endif
   - note: |

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -276,11 +276,13 @@ def claiming_less_than_full(amount, value):
         return False
 
 # DOJ Median Family Income thresholds for the Ch. 7 means test.
-# Source: https://www.justice.gov/ust/eo/bapcpa/20250515/bci_data/median_income_table.htm
-# Update when new DOJ tables are published (every ~6 months).
+# Source: https://www.justice.gov/ust/eo/bapcpa/20260715/bci_data/median_income_table.htm
+# (cases filed on or after July 15, 2026; pulled from the live DOJ table
+# 2026-07-29). Update when new DOJ tables are published (every ~6 months) —
+# these do NOT auto-update.
 DOJ_MEDIAN_INCOME_TABLES = {
-    'south dakota': {1: 61022, 2: 92469, 3: 96008, 4: 116374},
-    'nebraska':     {1: 65292, 2: 89130, 3: 103358, 4: 120323},
+    'south dakota': {1: 69190, 2: 89809, 3: 100883, 4: 130738},
+    'nebraska':     {1: 66922, 2: 90728, 3: 103405, 4: 125074},
 }
 DOJ_MEDIAN_ADDITIONAL_PER_PERSON = 11100
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -198,6 +198,13 @@ export interface CaseDetailsOptions {
   initialPaymentAmount?: string;
   /** Installments only: the proposed installment schedule (≥1 required). */
   installments?: Array<{ amount: string; date: string }>;
+  /**
+   * Installments only: an ISO date to try FIRST for installment 0. The helper
+   * expects the client-side 90-day cap (HTML5 max + jQuery validator) to
+   * reject it, then corrects it to `installments[0].date` and continues.
+   * Drives the failing branch of the Roxanne 2026-07 90-day cap.
+   */
+  invalidInstallmentDate?: string;
 }
 
 export interface TestScenario {

--- a/tests/installments-with-sofa-payments.spec.ts
+++ b/tests/installments-with-sofa-payments.spec.ts
@@ -47,10 +47,20 @@ const SCN: TestScenario = {
     feePayment: 'installments',
     paymentOnPetition: true,
     initialPaymentAmount: '78',
-    // ISO format — the collect page renders <input type="date">.
-    installments: [{ amount: '260', date: '2026-09-15' }],
+    // ISO format — the collect page renders <input type="date">. Computed
+    // relative to today so the 90-day cap assertions never go stale.
+    installments: [{ amount: '260', date: isoDaysFromNow(30) }],
+    // Tried first; the server-side 90-day cap (Roxanne UAT 2026-07-29) must
+    // reject it before the valid date above is accepted.
+    invalidInstallmentDate: isoDaysFromNow(120),
   },
 };
+
+function isoDaysFromNow(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
 
 test.setTimeout(600_000);
 
@@ -58,6 +68,14 @@ test('installments + SOFA consumer-debt payments assembles (global `payment` not
   page,
 }) => {
   await runFullInterview(page, SCN);
+
+  // Nav regression (Roxanne 2026-07-29): choosing installments used to
+  // overwrite nav section index 3 — the "Property" entry — with a duplicate
+  // "Case Detail". Property must still be in the left-hand menu.
+  await expect(
+    page.locator('.danavdiv, #daTOC, nav').first(),
+    'left-hand menu lost its "Property" section (nav index clobber)',
+  ).toContainText('Property');
 
   // The crash surfaced as an error page while assembling 103A. Assert the
   // interview reached assembly and produced the forms, including 103A.

--- a/tests/maximalist.spec.ts
+++ b/tests/maximalist.spec.ts
@@ -385,10 +385,15 @@ async function navigatePropertySectionMulti(page: Page) {
     // Hand off at the exemption boundary: the caller runs navigateExemptionSection
     // next, so just BREAK when we reach it — don't touch the gate. NE/SD skip the
     // exemption_type select, so detect the "Do you have any property to claim as
-    // exempt?" gate (a yesno-button screen) directly.
+    // exempt?" gate (a yesno-button screen) directly. The 730-day domicile
+    // screen (PR #132) now opens the exemption flow — it is a yesno-BUTTON page
+    // with no Continue button, so it must also break this Continue-clicking
+    // loop (navigateExemptionSection answers it).
     const exemptionSelect = page.locator(`select[name="${b64('prop.exempt_property.exemption_type')}"]`);
     const exemptGate = page.locator(`[name="${b64('prop.exempt_property.properties.there_are_any')}"]`);
-    if ((await exemptionSelect.count()) > 0 || (await exemptGate.count()) > 0 || /claim as exempt/i.test(heading || '')) {
+    const domicileBtn = page.locator(`button[name="${b64('prop.domicile_two_years')}"]`);
+    if ((await exemptionSelect.count()) > 0 || (await exemptGate.count()) > 0
+        || (await domicileBtn.count()) > 0 || /claim as exempt/i.test(heading || '')) {
       console.log('  [property] Reached exemption boundary, handing off to navigateExemptionSection');
       break;
     }
@@ -1448,10 +1453,23 @@ async function navigateCaseDetailsMaximalist(page: Page) {
     await districtSelect.selectOption('District of Nebraska');
   }
 
+  // Chapter select + discharge radio were added by PR #128 (727(a)(8)/(9)
+  // discharge-bar warning) — both required, so Continue silently refuses to
+  // advance if they're left blank. Answer discharge=No so the non-blocking
+  // warning screen (granted discharge inside the 8/6-year window) is skipped.
+  const chapterSelect = page.locator(`select[name="${b64('case.previous_bankruptcy[0].chapter')}"]`);
+  if (await chapterSelect.count() > 0) {
+    await chapterSelect.selectOption({ label: '7' });
+  }
+
   const whenField = page.locator(`#${b64('case.previous_bankruptcy[0].when')}`);
   if (await whenField.count() > 0) {
     await whenField.fill('2018-11-03');
+    await whenField.blur();
   }
+
+  await selectYesNoRadio(page, 'case.previous_bankruptcy[0].discharge_granted', false);
+  await page.waitForTimeout(300);
 
   const caseNumField = page.locator(`#${b64('case.previous_bankruptcy[0].case_number')}`);
   if (await caseNumField.count() > 0) {

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -1243,7 +1243,13 @@ export async function navigateCaseDetails(page: Page, opts: CaseDetailsOptions =
   // defines the global `payment` object read by the 103A builder.
   if (wantsInstallments) {
     const paymentOnPetition = opts.paymentOnPetition ?? true;
-    const installments = opts.installments ?? [{ amount: '100', date: '2026-09-15' }];
+    // Default date computed from today: the 103A page rejects dates more than
+    // 90 days out (Roxanne UAT 2026-07), so a hardcoded date would go stale.
+    const defaultDate = new Date();
+    defaultDate.setDate(defaultDate.getDate() + 45);
+    const installments = opts.installments ?? [
+      { amount: '100', date: defaultDate.toISOString().slice(0, 10) },
+    ];
 
     // installment_payment_intro (continue button field)
     await waitForDaPageLoad(page);
@@ -1263,6 +1269,41 @@ export async function navigateCaseDetails(page: Page, opts: CaseDetailsOptions =
     // on ONE page; item 0 is pre-rendered (minimum_number: 1) and further items
     // are added with the collect page's "Add another" control.
     await waitForDaPageLoad(page);
+
+    // Optionally drive the FAILING branch of the 90-day installment cap: try
+    // an over-limit date first and require the rejection message. The cap is
+    // the HTML5 `max` on the date field enforced by the client validator —
+    // server-side validation (question-level OR per-field) on this
+    // `list collect` page infinite-loops docassemble's re-render into an
+    // HTTP 501, so the max attribute is the only workable enforcement.
+    // clickContinue only sets `ignore: ':hidden'`, so visible-field rules
+    // like this one still run — the submit is genuinely blocked.
+    if (opts.invalidInstallmentDate) {
+      const amountField = page.locator(`#${b64('payment.payments[0].amount')}`);
+      const dateField = page.locator(`#${b64('payment.payments[0].proposed_date')}`);
+      await amountField.fill(installments[0].amount);
+      await dateField.fill(opts.invalidInstallmentDate);
+      // Blur commits the value so the client validator evaluates the cap now.
+      await dateField.blur();
+      await expect(
+        page.getByText(/within 90 days of the initial payment/).first(),
+        `installment date ${opts.invalidInstallmentDate} should be rejected by the 90-day cap`,
+      ).toBeVisible({ timeout: 15000 });
+      // Navigation must actually be blocked, not just flagged.
+      await clickContinue(page);
+      await expect(
+        dateField,
+        'over-limit installment date should keep the filer on the payment screen',
+      ).toBeVisible();
+      // Correct the date and wait for the error to clear BEFORE the real
+      // Continue click below: removing the error label reflows the page, and a
+      // click that lands mid-reflow misses the moving button (both for
+      // Playwright and for a real user's first click).
+      await dateField.fill(installments[0].date);
+      await dateField.blur();
+      await expect(page.getByText(/within 90 days of the initial payment/).first()).toBeHidden();
+    }
+
     for (let i = 0; i < installments.length; i++) {
       if (i > 0) {
         await page.locator('a.dacollectadd:visible, button.dacollectadd:visible').first().click();
@@ -1315,7 +1356,9 @@ export async function navigateCreditCounseling(page: Page, scenario: TestScenari
   const debtorCount = scenario.jointFiling ? 2 : 1;
   for (let d = 0; d < debtorCount; d++) {
     await waitForDaPageLoad(page);
-    await selectByName(page, b64('debtor[i].counseling.counseling_type'), '1');
+    // Radio field (was a dropdown that ran off screen — Roxanne UAT 2026-07);
+    // index 0 = "received a briefing ... and I received a certificate" ('1').
+    await selectChoiceRadio(page, 'debtor[i].counseling.counseling_type', 0);
     await clickContinue(page);
   }
 


### PR DESCRIPTION
Fixes for Roxanne's July 29 UAT feedback (the crash itself — the 107 `payment` clobber — already shipped in #150; this is everything else from her email, plus her means-test data question).

## Interview changes

1. **103A installment dates: 90-day cap.** Each proposed installment date is capped at 90 days out, with a plain-language message when a later date is entered, and the payment screens now spell out the 90-day requirement. Enforced with the HTML5 `max` attribute + client validator, **not** server-side: on a `list collect` page, both question-level `validation code` and per-field `validate` failures infinite-loop the post-validation re-render into an HTTP 501 (verified empirically; documented in a YAML comment so nobody re-walks into it).
2. **Credit counseling status (101) is a radio list, not a dropdown.** The four long statuses can't wrap inside a `<select>`, so the menu ran off the screen.
3. **Property summary missing real estate / Property vanishing from the left menu.** Choosing installments or a fee waiver overwrote nav section index 3 — the "Property" entry — with a duplicate "Case Detail". The fee subsection is now attached by key lookup, and the review heading is "Real Estate".
4. **Secured-debts collateral dropdown (106D)** labels real estate as `Real estate - <street address>` instead of leading with the stringified ownership-type dict that pushed the address out of view.
5. **DOJ median-income tables** updated to the 2026-07-15 DOJ table (pulled from the live justice.gov table 2026-07-29). They do not auto-update — answering Roxanne's question — and remain a manual ~6-month refresh. ⚠️ Statutory figures: worth an attorney/staff spot-check against justice.gov/ust/means-testing.

## Tests

- `installments-with-sofa-payments.spec.ts` drives the 90-day **failing branch** (over-limit date rejected client-side, corrected, then continues) and asserts the Property nav entry survives choosing installments — through full PDF assembly (101/103/106/107/122).
- Helpers updated for the counseling radio and the labeled collateral dropdown.
- **Maximalist spec fixes (both pre-existing on `main`, from the 2026-06-19 merges — the spec hadn't been run since the 06-11 full-suite green):**
  - the property post-deposit loop now hands off at the 730-day domicile screen — a yesno-button page added by #132 that the Continue-clicking loop predates;
  - the previous-bankruptcy list-collect now fills the required Chapter select and discharge radio added by #128 — blank required fields made Continue silently refuse to advance.

Verified: installments spec, maximalist, and income-review-edit all pass end-to-end against the local deploy; lint gates clean (flow, pdf-fields, test-complete, caps-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUZ94ArnHybSn2AJVpjTnX
