### PR TITLE
Conclusion screen: download-before-leaving guidance (Shirley UAT 2026-07-31)

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -1376,6 +1376,12 @@ subquestion: |
   Your Chapter 7 bankruptcy petition documents are ready for download.
   Please review all documents with your attorney before filing.
 
+  **Download your documents now, before leaving this page.** If you use the
+  option to email the documents to yourself, still download them here first:
+  email can be delayed or blocked by spam filters, and this page is the only
+  reliable way to get your completed forms. If you do request an email and it
+  does not arrive, check your spam or junk folder.
+
   **Creditor Mailing Matrix (plain text for CM/ECF upload):**
 
   [**Download the creditor matrix** (creditor_matrix.txt)](${ mailing_matrix_file.url_for(attachment=True) })

--- a/tests/installments-with-sofa-payments.spec.ts
+++ b/tests/installments-with-sofa-payments.spec.ts
@@ -81,6 +81,14 @@ test('installments + SOFA consumer-debt payments assembles (global `payment` not
   // interview reached assembly and produced the forms, including 103A.
   const pdfs = await finishAndAssertAllPdfs(page, { mustInclude: ['101', '103', '106', '107', '122'] });
 
+  // Shirley 2026-07-31: she left the conclusion screen without downloading,
+  // expecting the email copy — which never arrived. The screen must tell
+  // users to download before leaving.
+  await expect(
+    page.locator('body'),
+    'conclusion screen is missing the download-before-leaving guidance',
+  ).toContainText('Download your documents now, before leaving this page');
+
   const names = pdfs.map((p) => p.name.toLowerCase()).join(' | ');
   expect(names, 'Form 103A (installment application) did not assemble').toContain('103');
 });


### PR DESCRIPTION
## Feedback

Shirley Peng (Legal Aid NE, 2026-07-31, "BK Pro Se Software" / "bankruptcy system mail" thread): she completed a full run-through with no issues, chose to have the petition emailed, and left the conclusion screen without downloading — then the email never arrived (not in spam either). The deliverability side (Mailgun → Exchange quarantine trace) is being handled separately with Infinet; this PR closes the UX gap that left her with no documents at all.

## Change

The conclusion screen now leads with an explicit instruction: download the documents before leaving the page; the email option is a convenience copy that can be delayed or spam-filtered, and users who request an email should check spam if it doesn't arrive. No flow, variable, or builder-key changes — subquestion text only. The built-in email option is left in place (removing it is a product call Alex has deferred to launch prep).

## Test evidence

- `tests/installments-with-sofa-payments.spec.ts` extended to assert the new guidance is visible on the conclusion screen after full PDF assembly — passed end-to-end against the local container (1 passed, 2.8m).
- Lint gates: flow-gaps, test-completeness, caps-sync, namespace-clobber, seek-sim all clean; yaml-ids and selectors trivially unaffected (0 `id:` changes, no banned selectors); pdf-fields unaffected (no builder-key changes; the local checker run skipped template reads for environment reasons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
