### PR TITLE
Fix three issues from Phil Martin's UAT feedback

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -486,7 +486,10 @@ code: |
     def _gi(_d, _a):
       return _num(getattr(_d.income, _a, 0))
     _income_total = (_gi(debt, 'net_rental_business') + _gi(debt, 'family_support') + _gi(debt, 'interest_and_dividends') + _gi(debt, 'unemployment') + _gi(debt, 'social_security') + _gi(debt, 'other_govt_assist') + _gi(debt, 'pension') + _other_month)
-    _paystub_total = (_gi(debt, 'income_amount_1') + _gi(debt, 'income_amount_2') + _gi(debt, 'income_amount_3') + _gi(debt, 'income_amount_4') + _gi(debt, 'income_amount_5') + _gi(debt, 'income_amount_6') + _gi(debt, 'overtime_pay_1') + _gi(debt, 'overtime_pay_2') + _gi(debt, 'overtime_pay_3'))
+    # gross_monthly_wages() sums all six job slots INCLUDING overtime 4-6, which
+    # this line used to drop (overtime_pay_4/5/6 silently vanished from the
+    # Form 101 income estimate for anyone with four or more jobs).
+    _paystub_total = _num(gross_monthly_wages(debt.income))
     _deductions = (_gi(debt, 'tax_deduction') + _gi(debt, 'mandatory_contributions') + _gi(debt, 'voluntary_contributions') + _gi(debt, 'fund_loans') + _gi(debt, 'insurance') + _gi(debt, 'domestic_support') + _gi(debt, 'union_dues') + _other_ded)
     _overall += _income_total + _paystub_total - _deductions
   overallIncome = _overall
@@ -1048,6 +1051,7 @@ attachment:
   - name: Form 101
     filename: b_101.pdf
     pdf template file: b_101.pdf
+    editable: pdf_editable
     code: main
     variable name: attach_101
 ---
@@ -1376,6 +1380,13 @@ subquestion: |
   Your Chapter 7 bankruptcy petition documents are ready for download.
   Please review all documents with your attorney before filing.
 
+  **The first item in the list below — "Complete petition packet" — contains
+  every form in a single PDF.** The individual forms are listed underneath it if
+  you need them separately. If you email the documents to yourself, each form
+  arrives as its own attachment, so scroll through the whole list of attachments
+  in your email (or just use the combined packet) to be sure you have all of
+  them, not only Form 101.
+
   **Download your documents now, before leaving this page.** If you use the
   option to email the documents to yourself, still download them here first:
   email can be delayed or blocked by spam filters, and this page is the only
@@ -1447,7 +1458,24 @@ code: |
     _docs.append(attach_122a2)
   if defined('attach_2030'):
     _docs.append(attach_2030)
-  conclusion_attachments = _docs
+  # Put the whole petition into ONE pdf and offer it first. Both the download
+  # list and the "e-mail these documents" form hand over every attachment
+  # separately, so a filer who emails the packet to themselves gets ~20 separate
+  # PDFs -- easy to mistake for "only Form 101 came through" (Phil Martin, UAT
+  # August 2026). The individual forms are still listed below the packet.
+  _packet_pdf = pdf_concatenate(_docs, filename='bankruptcy_petition_packet.pdf')
+  petition_packet = DAFileCollection('petition_packet')
+  petition_packet.pdf = _packet_pdf
+  petition_packet.info = {
+    'name': 'Complete petition packet (all forms in one file)',
+    'filename': 'bankruptcy_petition_packet',
+    'description': 'Every form below, combined into a single PDF for printing or filing.',
+    'formats': ['pdf'],
+    'valid_formats': ['pdf'],
+    'extension': {'pdf': 'pdf'},
+    'mimetype': {'pdf': 'application/pdf'},
+  }
+  conclusion_attachments = [petition_packet] + _docs
 ---
 id: review_answers
 event: review_answers

--- a/docassemble/BankruptcyClinic/data/questions/101A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101A-question-blocks.yml
@@ -36,12 +36,14 @@ fields:
 attachment:
   filename: form_b101b.pdf
   pdf template file: form_b101b.pdf
+  editable: pdf_editable
   code: evict2
   variable name: attach_101b
 ---
 attachment:
   filename: form_b101a.pdf
   pdf template file: form_b101a.pdf
+  editable: pdf_editable
   code: evict
   variable name: attach_101a
 ---

--- a/docassemble/BankruptcyClinic/data/questions/103A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/103A-question-blocks.yml
@@ -142,6 +142,7 @@ attachment:
   name: Form 103a
   filename: form_b103a.pdf
   pdf template file: form_b103a.pdf
+  editable: pdf_editable
   code: pymts
   variable name: attach_103a
 ---

--- a/docassemble/BankruptcyClinic/data/questions/103B-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/103B-question-blocks.yml
@@ -28,11 +28,11 @@ fields:
       Make sure to include the value (if known) of any non-cash governmental assistance that you receive, such as food stamps (benefits under the Supplemental Nutrition Assistance Program) or housing subsidies.
   - Your income: family.you_income
     datatype: currency
-    default: ${ debtor[0].income.income_amount_1 + debtor[0].income.overtime_pay_1 + debtor[0].income.net_rental_business + debtor[0].income.social_security + debtor[0].income.pension + debtor[0].income.unemployment + debtor[0].income.family_support + debtor[0].income.interest_and_dividends + debtor[0].income.other_govt_assist if defined('debtor[0].income.income_amount_1') else 0 }
+    default: ${ gross_monthly_wages(debtor[0].income) + debtor[0].income.net_rental_business + debtor[0].income.social_security + debtor[0].income.pension + debtor[0].income.unemployment + debtor[0].income.family_support + debtor[0].income.interest_and_dividends + debtor[0].income.other_govt_assist if defined('debtor[0].income.income_amount_1') else 0 }
   - Your spouse's income: family.spouse_income
     datatype: currency
     required: False
-    default: ${ debtor[1].income.income_amount_1 + debtor[1].income.overtime_pay_1 + debtor[1].income.net_rental_business + debtor[1].income.social_security + debtor[1].income.pension + debtor[1].income.unemployment + debtor[1].income.family_support + debtor[1].income.interest_and_dividends + debtor[1].income.other_govt_assist if len(debtor) > 1 and defined('debtor[1].income.income_amount_1') else 0 }
+    default: ${ gross_monthly_wages(debtor[1].income) + debtor[1].income.net_rental_business + debtor[1].income.social_security + debtor[1].income.pension + debtor[1].income.unemployment + debtor[1].income.family_support + debtor[1].income.interest_and_dividends + debtor[1].income.other_govt_assist if len(debtor) > 1 and defined('debtor[1].income.income_amount_1') else 0 }
   - Non-cash assistance: family.assistance_income
     datatype: currency
   - note: |
@@ -302,6 +302,7 @@ attachment:
   - name: Form 103b
     filename: form_b103b.pdf
     pdf template file: form_b103b.pdf
+    editable: pdf_editable
     code: waive
     variable name: form_103b_attach
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106AB-question-blocks.yml
@@ -5137,6 +5137,7 @@ attachment:
   - name: Form 106AB
     filename: form_b106ab.pdf
     pdf template file: form_b106ab.pdf
+    editable: pdf_editable
     code: ab
     variable name: ab_attach
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106C-question-blocks.yml
@@ -390,5 +390,6 @@ attachment:
   - name: Form 106C
     filename: form_b106c.pdf
     pdf template file: form_b_106c.pdf
+    editable: pdf_editable
     variable name: c_attach
     code: sc

--- a/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106D-question-blocks.yml
@@ -322,6 +322,7 @@ attachment:
   - name: Form 106D
     filename: form_b106d.pdf
     pdf template file: form_b106d.pdf
+    editable: pdf_editable
     code: claims
     variable name: d_attach
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106Dec-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106Dec-question-blocks.yml
@@ -8,6 +8,7 @@ attachment:
   - name: Form 106 Declaration
     filename: form_b106dec.pdf
     pdf template file: form_b106dec.pdf
+    editable: pdf_editable
     variable name: declaration_attach
     code: declaration_fields
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106EF-question-blocks.yml
@@ -659,6 +659,7 @@ attachment:
   - name: Form 106EF
     filename: form_b106ef.pdf
     pdf template file: form_b106ef.pdf
+    editable: pdf_editable
     variable name: ef_attach
     code: unsecured_claims
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106G-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106G-question-blocks.yml
@@ -108,6 +108,7 @@ attachment:
   - name: Form 106G
     filename: form_b106g.pdf
     pdf template file: form_b106g.pdf
+    editable: pdf_editable
     variable name: g_attach
     code: contracts
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106H-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106H-question-blocks.yml
@@ -193,6 +193,7 @@ attachment:
   - name: Form 106H
     filename: form_b106h.pdf
     pdf template file: form_b106h.pdf
+    editable: pdf_editable
     variable name: h_attach
     code: codebtors
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106I-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106I-question-blocks.yml
@@ -60,48 +60,66 @@ question: Give details about monthly income
 subquestion: |
     Estimate your **expected** monthly income at the time of filing, not necessarily what you earned last month. The purpose of Schedule I is to show the court your budget during the bankruptcy. If last month was unusual (e.g., due to job change, seasonal work, or one-time payments), adjust your figures to reflect your typical ongoing income.
 
-    If you have nothing to report for any line, write 0. Include your non-filing spouse unless you are separated. If you or your non-filing spouse have more than one employer, combine the information for all employers for that person on the lines below.
+    **Enter a MONTHLY amount, not the amount on one pay stub.** There is one row
+    below for each job you hold. Most people fill in **Job 1 only**. The extra
+    rows are for a *second or third employer*, not for a second or third
+    paycheck from the same employer — do not list six pay stubs here, or your
+    monthly income will come out several times too high.
 
-    Please enter your pay stub information for a typical recent month.
+    To turn your pay stub into a monthly amount:
+
+    * Paid **weekly**: gross pay on one stub &times; 52 &divide; 12 (about &times; 4.33)
+    * Paid **every two weeks**: gross pay on one stub &times; 26 &divide; 12 (about &times; 2.17)
+    * Paid **twice a month**: gross pay on one stub &times; 2
+    * Paid **monthly**: the amount on the stub
+
+    If you have nothing to report for a line, write 0. Include your non-filing
+    spouse's job(s) on the rows below unless you are separated.
 fields:
-  - note: Check 1
-  - Gross wages, salary, and commissions: debtor[0].income.income_amount_1
+  - note: |
+      **Job 1** &mdash; monthly gross pay from your main employer
+  - Gross wages, salary, and commissions (per month): debtor[0].income.income_amount_1
     datatype: currency
   - Estimate and list monthly overtime pay: debtor[0].income.overtime_pay_1
     datatype: currency
 
-  - note: Check 2
-  - Gross wages, salary, and commissions: debtor[0].income.income_amount_2
+  - note: |
+      **Job 2** &mdash; only if you (or a non-filing spouse) have a second employer. Leave blank otherwise.
+  - Gross wages, salary, and commissions (per month): debtor[0].income.income_amount_2
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[0].income.overtime_pay_2
     datatype: currency
     required: False
 
-  - note: Check 3
-  - Gross wages, salary, and commissions: debtor[0].income.income_amount_3
+  - note: |
+      **Job 3** &mdash; only if there is a third employer.
+  - Gross wages, salary, and commissions (per month): debtor[0].income.income_amount_3
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[0].income.overtime_pay_3
     datatype: currency
     required: False
 
-  - note: Check 4
-  - Gross wages, salary, and commissions: debtor[0].income.income_amount_4
+  - note: |
+      **Job 4** &mdash; only if there is a fourth employer.
+  - Gross wages, salary, and commissions (per month): debtor[0].income.income_amount_4
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[0].income.overtime_pay_4
     datatype: currency
     required: False
-  - note: Check 5
-  - Gross wages, salary, and commissions: debtor[0].income.income_amount_5
+  - note: |
+      **Job 5** &mdash; only if there is a fifth employer.
+  - Gross wages, salary, and commissions (per month): debtor[0].income.income_amount_5
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[0].income.overtime_pay_5
     datatype: currency
     required: False
-  - note: Check 6
-  - Gross wages, salary, and commissions: debtor[0].income.income_amount_6
+  - note: |
+      **Job 6** &mdash; only if there is a sixth employer.
+  - Gross wages, salary, and commissions (per month): debtor[0].income.income_amount_6
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[0].income.overtime_pay_6
@@ -342,48 +360,65 @@ question: Give details about Debtor 2 monthly income
 subquestion: |
     Estimate Debtor 2's **expected** monthly income at the time of filing, not necessarily what was earned last month. The purpose of Schedule I is to show the court your budget during the bankruptcy.
 
-    If you have nothing to report for any line, write 0. If you or your non-filing spouse have more than one employer, combine the information for all employers for that person on the lines below.
+    **Enter a MONTHLY amount, not the amount on one pay stub.** There is one row
+    below for each job Debtor 2 holds. Most people fill in **Job 1 only**. The
+    extra rows are for a *second or third employer*, not for a second or third
+    paycheck from the same employer — do not list six pay stubs here, or the
+    monthly income will come out several times too high.
 
-    Please enter pay stub information for a typical recent month.
+    To turn a pay stub into a monthly amount:
+
+    * Paid **weekly**: gross pay on one stub &times; 52 &divide; 12 (about &times; 4.33)
+    * Paid **every two weeks**: gross pay on one stub &times; 26 &divide; 12 (about &times; 2.17)
+    * Paid **twice a month**: gross pay on one stub &times; 2
+    * Paid **monthly**: the amount on the stub
+
+    If you have nothing to report for a line, write 0.
 fields:
-  - note: Check 1
-  - Gross wages, salary, and commissions: debtor[1].income.income_amount_1
+  - note: |
+      **Job 1** &mdash; monthly gross pay from Debtor 2's main employer
+  - Gross wages, salary, and commissions (per month): debtor[1].income.income_amount_1
     datatype: currency
   - Estimate and list monthly overtime pay: debtor[1].income.overtime_pay_1
     datatype: currency
 
-  - note: Check 2
-  - Gross wages, salary, and commissions: debtor[1].income.income_amount_2
+  - note: |
+      **Job 2** &mdash; only if Debtor 2 has a second employer. Leave blank otherwise.
+  - Gross wages, salary, and commissions (per month): debtor[1].income.income_amount_2
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[1].income.overtime_pay_2
     datatype: currency
     required: False
 
-  - note: Check 3
-  - Gross wages, salary, and commissions: debtor[1].income.income_amount_3
+  - note: |
+      **Job 3** &mdash; only if there is a third employer.
+  - Gross wages, salary, and commissions (per month): debtor[1].income.income_amount_3
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[1].income.overtime_pay_3
     datatype: currency
     required: False
 
-  - note: Check 4
-  - Gross wages, salary, and commissions: debtor[1].income.income_amount_4
+  - note: |
+      **Job 4** &mdash; only if there is a fourth employer.
+  - Gross wages, salary, and commissions (per month): debtor[1].income.income_amount_4
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[1].income.overtime_pay_4
     datatype: currency
     required: False
-  - note: Check 5
-  - Gross wages, salary, and commissions: debtor[1].income.income_amount_5
+  - note: |
+      **Job 5** &mdash; only if there is a fifth employer.
+  - Gross wages, salary, and commissions (per month): debtor[1].income.income_amount_5
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[1].income.overtime_pay_5
     datatype: currency
     required: False
-  - note: Check 6
-  - Gross wages, salary, and commissions: debtor[1].income.income_amount_6
+  - note: |
+      **Job 6** &mdash; only if there is a sixth employer.
+  - Gross wages, salary, and commissions (per month): debtor[1].income.income_amount_6
     datatype: currency
     required: False
   - Estimate and list monthly overtime pay: debtor[1].income.overtime_pay_6
@@ -731,6 +766,7 @@ attachment:
   - name: Form 106I
     filename: form_b106i.pdf
     pdf template file: form_b106i.pdf
+    editable: pdf_editable
     variable name: i_attach
     code: income1
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106J-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106J-question-blocks.yml
@@ -339,6 +339,7 @@ attachment:
   - name: Form 106J
     filename: form_b106j.pdf
     pdf template file: form_b106j.pdf
+    editable: pdf_editable
     variable name: j_attach
     code: expenses
 ---

--- a/docassemble/BankruptcyClinic/data/questions/106Sum-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106Sum-question-blocks.yml
@@ -8,6 +8,7 @@ attachment:
   - name: Form 106 Summary
     filename: form_b106sum.pdf
     pdf template file: form_b106sum.pdf
+    editable: pdf_editable
     variable name: summary_attach
     code: summary_fields
 ---

--- a/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/107-question-blocks.yml
@@ -2295,6 +2295,7 @@ attachment:
   - name: Form 107Ext1
     filename: form_b107ext1.pdf
     pdf template file: form_b_107_ext1.pdf
+    editable: pdf_editable
     variable name: form_107_ext1
     code: fin
 ---
@@ -2302,6 +2303,7 @@ attachment:
   - name: Form 107Ext2
     filename: form_b107ext2.pdf
     pdf template file: form_b_107_ext2.pdf
+    editable: pdf_editable
     variable name: form_107_ext2
     code: fin
 ---
@@ -2309,6 +2311,7 @@ attachment:
   - name: Form 107
     filename: form_b107_v2.pdf
     pdf template file: form_b_107_v2.pdf
+    editable: pdf_editable
     variable name: form_107_temp
     code: fin
 ---
@@ -2316,6 +2319,7 @@ attachment:
   - name: Form 107Ext3
     filename: form_b107ext3.pdf
     pdf template file: form_b_107_ext3.pdf
+    editable: pdf_editable
     variable name: form_107_ext3
     code: fin
 ---

--- a/docassemble/BankruptcyClinic/data/questions/108-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/108-question-blocks.yml
@@ -82,6 +82,7 @@ attachment:
   - name: Form 108
     filename: form_b108.pdf
     pdf template file: form_b108.pdf
+    editable: pdf_editable
     variable name: attach_108
     code: leases
 ---

--- a/docassemble/BankruptcyClinic/data/questions/121-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/121-question-blocks.yml
@@ -59,6 +59,7 @@ attachment:
   - name: Form 121
     filename: form_b121.pdf
     pdf template file: form_b121.pdf
+    editable: pdf_editable
     variable name: attach_121
     code: ssn
 ---

--- a/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/122A-question-blocks.yml
@@ -63,7 +63,7 @@ fields:
       % endif
   - Your gross wages, salary, tips, bonuses, overtime, and commissions: monthly_income.gross_wages1
     datatype: currency
-    default: ${ getattr(debtor[0].income, 'income_amount_1', 0) + getattr(debtor[0].income, 'overtime_pay_1', 0) }
+    default: ${ gross_monthly_wages(debtor[0].income) }
   - Alimony and maintenance payments: monthly_income.alimony1
     datatype: currency
     default: ${ debtor[0].income.family_support }
@@ -141,7 +141,7 @@ fields:
       % endif
   - Your gross wages, salary, tips, bonuses, overtime, and commissions: monthly_income.gross_wages2
     datatype: currency
-    default: ${ (getattr(debtor[1].income, 'income_amount_1', 0) + getattr(debtor[1].income, 'overtime_pay_1', 0)) if len(debtor) > 1 else 0 }
+    default: ${ gross_monthly_wages(debtor[1].income) if len(debtor) > 1 else 0 }
   - Alimony and maintenance payments: monthly_income.alimony2
     datatype: currency
     default: ${ debtor[1].income.family_support if len(debtor) > 1 else 0 }
@@ -350,6 +350,7 @@ attachment:
   - name: Form 122a
     filename: form_b22a-1.pdf
     pdf template file: b_122a-1.pdf
+    editable: pdf_editable
     variable name: attach_122a
     code: income
 ---

--- a/docassemble/BankruptcyClinic/data/questions/2030-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/2030-question-blocks.yml
@@ -219,6 +219,7 @@ attachment:
   - name: Form B2030 Disclosure of Compensation
     filename: form_b2030
     pdf template file: form_b2030.pdf
+    editable: pdf_editable
     variable name: attach_2030
     code: b2030_fields
 ---

--- a/docassemble/BankruptcyClinic/data/questions/cross-validation.yml
+++ b/docassemble/BankruptcyClinic/data/questions/cross-validation.yml
@@ -35,10 +35,11 @@ code: |
       # Issue #76: Income validation
       if (defined('family.you_income') and defined('debtor[0].income')):
         d0_income = debtor[0].income
-        income_section_total = 0
+        # All six job slots, matching Schedule I and the fee-waiver default.
+        income_section_total = gross_monthly_wages(d0_income)
 
-        # Sum income fields that exist
-        income_fields = ['income_amount_1', 'overtime_pay_1', 'net_rental_business', 'social_security', 'pension', 'unemployment', 'family_support', 'interest_and_dividends', 'other_govt_assist']
+        # Sum the remaining (non-wage) income fields that exist
+        income_fields = ['net_rental_business', 'social_security', 'pension', 'unemployment', 'family_support', 'interest_and_dividends', 'other_govt_assist']
         for field in income_fields:
           if hasattr(d0_income, field):
             val = getattr(d0_income, field)

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -351,6 +351,13 @@ objects:
 ---
 mandatory: true
 code: |
+  # Assembled PDFs are FLATTENED (editable = False) so the official B-form
+  # "Reset" pushbutton and the embedded form JavaScript cannot survive into the
+  # filer's copy -- a tester pressed Reset on an emailed PDF and it wiped the
+  # whole form. 21 of the 27 USCourts templates ship that button.
+  # `?pdf_editable=1` opts back into fillable output; the Playwright specs that
+  # read AcroForm values use it, real users never do.
+  pdf_editable = str(url_args.get('pdf_editable', '')).lower() in ('1', 'true', 'yes')
   introduction_screen
   current_district
   chapter = "Chapter 7"

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -168,6 +168,25 @@ def mark_list_emptied(the_list):
     the_list.gathered = True
 
 
+def gross_monthly_wages(income, include_overtime=True):
+    """Total monthly gross wages across all six job slots on the Schedule I
+    pay screen (`income_amount_1..6`, plus `overtime_pay_1..6`).
+
+    The screen offers six rows because a filer (or a non-filing spouse) can
+    hold several jobs; Schedule I, Schedule J and Form 101 all sum every row.
+    Form 122A (means test) and Form 103B (fee waiver) used to pre-fill from
+    slot 1 only, so a filer with two jobs saw a means-test figure that silently
+    disagreed with their own Schedule I. Everything goes through this function
+    now so there is one definition of "gross monthly wages" (Phil Martin, UAT
+    August 2026)."""
+    total = 0
+    for slot in range(1, 7):
+        total += getattr(income, 'income_amount_' + str(slot), 0) or 0
+        if include_overtime:
+            total += getattr(income, 'overtime_pay_' + str(slot), 0) or 0
+    return total
+
+
 def state_abbr(value):
     """Return the 2-letter abbreviation for a state name; pass through if already
     an abbreviation or unrecognized. Used to keep court-form PDF fields in the

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -16,8 +16,20 @@ const BASE_URL = _POOL.length > 0
   ? _POOL[_WORKER % _POOL.length]
   : (process.env.BASE_URL || 'http://localhost:8080');
 const INTERVIEW_PACKAGE = process.env.INTERVIEW_PACKAGE || 'docassemble.BankruptcyClinic:data/questions/voluntary-petition.yml';
-export const INTERVIEW_URL =
+
+/** What a real user gets: assembled PDFs are FLATTENED, so the official B-form
+ *  "Reset" pushbutton and embedded JavaScript cannot survive into the filer's
+ *  copy (a tester pressed Reset on an emailed PDF and it wiped the form).
+ *  `pdf-flattening.spec.ts` drives this URL and asserts the buttons are gone. */
+export const PRODUCTION_INTERVIEW_URL =
   `${BASE_URL}/interview?i=${INTERVIEW_PACKAGE}#page1`;
+
+/** Default test URL. `pdf_editable=1` opts back into fillable AcroForm output so
+ *  the ~9 specs that read field VALUES out of the assembled PDFs still can.
+ *  The query arg must sit before the `#` fragment to reach docassemble's
+ *  `url_args`. */
+export const INTERVIEW_URL =
+  `${BASE_URL}/interview?i=${INTERVIEW_PACKAGE}&pdf_editable=1#page1`;
 
 /** Base64-url-encode a docassemble field name (strips trailing '=' padding). */
 export const b64 = (str: string): string =>

--- a/tests/navigation-helpers.ts
+++ b/tests/navigation-helpers.ts
@@ -33,8 +33,10 @@ import { TestScenario, MeansTestOptions, CaseDetailsOptions, DebtorProfile, Real
 //  INTRO → DEBTOR PAGE
 // ════════════════════════════════════════════════════════════════════
 
-export async function navigateToDebtorPage(page: Page, scenario: TestScenario) {
-  await page.goto(INTERVIEW_URL + '&new_session=1');
+/** `startUrl` overrides the interview URL — pass `PRODUCTION_INTERVIEW_URL` to
+ *  exercise the flattened (non-fillable) PDF output real users receive. */
+export async function navigateToDebtorPage(page: Page, scenario: TestScenario, startUrl?: string) {
+  await page.goto((startUrl ?? INTERVIEW_URL) + '&new_session=1');
   await waitForDaPageLoad(page);
 
   // Intro
@@ -1777,7 +1779,7 @@ export async function navigateDynamicPhase(page: Page, scenario: TestScenario) {
 //  FULL INTERVIEW RUNNER
 // ════════════════════════════════════════════════════════════════════
 
-export async function runFullInterview(page: Page, scenario: TestScenario) {
+export async function runFullInterview(page: Page, scenario: TestScenario, startUrl?: string) {
   console.log(`\n${'═'.repeat(60)}`);
   console.log(`  TEST: ${scenario.name}`);
   console.log(`  District: ${scenario.district}`);
@@ -1789,7 +1791,7 @@ export async function runFullInterview(page: Page, scenario: TestScenario) {
 
   const log = (step: string) => console.log(`  [${step}] starting...`);
 
-  log('debtorPage'); await navigateToDebtorPage(page, scenario);
+  log('debtorPage'); await navigateToDebtorPage(page, scenario, startUrl);
   log('fillDebtor1'); await fillDebtorAndAdvance(page, scenario.debtor);
 
   if (scenario.jointFiling && scenario.spouse) {

--- a/tests/pdf-flattening.spec.ts
+++ b/tests/pdf-flattening.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression: the assembled PDFs a real user receives must be FLATTENED, and
+ * the whole petition must be available as ONE file.
+ *
+ * Phil Martin (Legal Aid of Nebraska, UAT August 2026) reported two problems
+ * with the documents he was emailed:
+ *
+ *   1. "on the pdf that was emailed to me has a 'Reset' button at the bottom.
+ *      I pushed it just to see if it would work. It does. It deleted
+ *      everything."  21 of the 27 official USCourts B-form templates ship a
+ *      /ResetForm pushbutton plus embedded form JavaScript, and nothing set
+ *      `editable:` on the attachments, so every assembled form went out as a
+ *      live fillable form with a working wipe-everything button.
+ *   2. "it looks like only the first 9 pages are there. Only Form 101 but none
+ *      of the Schedules" — ~20 separate attachments in one email is easy to
+ *      read as "only Form 101 arrived".
+ *
+ * This spec drives PRODUCTION_INTERVIEW_URL — i.e. WITHOUT the `pdf_editable=1`
+ * override the other specs use to keep reading AcroForm values — so it
+ * exercises exactly what a filer downloads.
+ */
+import { test, expect } from '@playwright/test';
+import { SIMPLE_SINGLE } from './fixtures';
+import { runFullInterview } from './navigation-helpers';
+import { downloadAllPdfs, findPdf } from './pdf-helpers';
+import { finishAndAssertAllPdfs } from './assert-helpers';
+import { PRODUCTION_INTERVIEW_URL, screenshot } from './helpers';
+
+test.describe('Assembled PDFs are flattened and offered as one packet', () => {
+  test.setTimeout(420_000);
+
+  test('no Reset button, no fillable fields, and a combined petition packet', async ({ page }) => {
+    await runFullInterview(page, SIMPLE_SINGLE, PRODUCTION_INTERVIEW_URL);
+    await screenshot(page, 'pdf-flattening-conclusion');
+
+    // Whole deliverable assembled, no error page. minPdfs is 15 as elsewhere;
+    // the combined packet is an extra download on top of the individual forms.
+    const pdfs = await finishAndAssertAllPdfs(page);
+    console.log(`  Downloaded ${pdfs.length} PDFs`);
+    for (const p of pdfs) console.log(`    - ${p.name} (${p.pages}p, ${Object.keys(p.fields).length} fields)`);
+
+    // ── 1. Every delivered PDF is flattened ──
+    for (const pdf of pdfs) {
+      expect(pdf.pages, `${pdf.name} has no pages`).toBeGreaterThan(0);
+
+      // getPdfFieldValues() returns {} when there is no AcroForm at all. This
+      // is the assertion that matters: pdftk's `flatten` stamps the field
+      // appearances into the page content and drops every widget annotation,
+      // so there is no longer anything to click. (The literal "ResetForm"
+      // string can still linger in an orphaned object / the document-level
+      // JavaScript name tree — with zero widget annotations nothing can
+      // trigger it, so the raw bytes are the wrong thing to assert on.)
+      const fieldNames = Object.keys(pdf.fields);
+      expect(
+        fieldNames,
+        `${pdf.name} still has fillable form fields (not flattened): ${fieldNames.slice(0, 5).join(', ')}`,
+      ).toHaveLength(0);
+    }
+
+    // ── 2. The whole petition is downloadable as a single file ──
+    const packet = pdfs.find((p) => /packet/i.test(p.name));
+    expect(packet, 'no combined petition packet was offered on the conclusion page').toBeTruthy();
+
+    const form101 = findPdf(pdfs, '101');
+    expect(form101).toBeTruthy();
+
+    // The packet is the concatenation of every form, so it must be
+    // substantially longer than Form 101 alone (Phil got 9 pages and thought
+    // that was the whole filing).
+    const otherPages = pdfs
+      .filter((p) => p !== packet)
+      .reduce((sum, p) => sum + p.pages, 0);
+    console.log(`  Packet: ${packet!.pages} pages; individual forms total ${otherPages}`);
+    expect(packet!.pages).toBe(otherPages);
+    expect(packet!.pages).toBeGreaterThan(form101!.pages);
+  });
+
+  test('the pdf_editable=1 test override still produces fillable forms', async ({ page }) => {
+    // Guards the escape hatch the field-value specs depend on: if this ever
+    // stops working, those specs would silently assert against empty field
+    // maps instead of failing loudly.
+    await runFullInterview(page, SIMPLE_SINGLE);
+    const pdfs = await downloadAllPdfs(page);
+    const form101 = findPdf(pdfs, '101');
+    expect(form101).toBeTruthy();
+    expect(Object.keys(form101!.fields).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/pdf-helpers.ts
+++ b/tests/pdf-helpers.ts
@@ -57,18 +57,25 @@ export async function assertPdfContains(
 
 /** Download all PDFs from the conclusion page. Returns array of PdfInfo. */
 export async function downloadAllPdfs(page: Page): Promise<PdfInfo[]> {
+  // Pair each download link with the heading of the attachment block it sits
+  // in, by walking the document in order and remembering the last heading seen.
+  // (Pairing headings to links by index breaks as soon as one attachment's
+  // heading does not start with "Form" — e.g. the combined petition packet.)
   const downloadLinks = await page.evaluate(() => {
-    const links = document.querySelectorAll('a[href*="/uploadedfile/"]');
-    return Array.from(links).map(a => ({
-      name: a.textContent?.trim() || '',
-      href: (a as HTMLAnchorElement).href,
-    }));
-  });
-
-  const formHeadings = await page.evaluate(() => {
-    return Array.from(document.querySelectorAll('h3'))
-      .map(h => h.textContent?.trim() || '')
-      .filter(t => t.toLowerCase().startsWith('form'));
+    const nodes = document.querySelectorAll('h1, h2, h3, h4, a[href*="/uploadedfile/"]');
+    let heading = '';
+    const out: { name: string; href: string }[] = [];
+    for (const el of Array.from(nodes)) {
+      if (el.tagName === 'A') {
+        out.push({
+          name: heading || (el.textContent?.trim() ?? ''),
+          href: (el as HTMLAnchorElement).href,
+        });
+      } else {
+        heading = el.textContent?.trim() || '';
+      }
+    }
+    return out;
   });
 
   const pdfInfos: PdfInfo[] = [];
@@ -79,7 +86,7 @@ export async function downloadAllPdfs(page: Page): Promise<PdfInfo[]> {
     const pdfDoc = await PDFDocument.load(buffer, { ignoreEncryption: true });
     const fields = await getPdfFieldValues(buffer);
     pdfInfos.push({
-      name: formHeadings[i] || downloadLinks[i].name,
+      name: downloadLinks[i].name,
       href: downloadLinks[i].href,
       buffer,
       pages: pdfDoc.getPageCount(),


### PR DESCRIPTION
Legal Aid of Nebraska ran the interview end to end (Phil Martin, Aug 2026) and reported three problems with the packet that landed in their inbox.

## 1. Six income slots read as "the past six pay stubs"

> "It has 6 slots to record paystubs... I thought it was asking for the past 6 paystubs total. So after I put those in it made my monthly income look crazy high."

The Schedule I pay screen labeled its slots "Check 1..6". They are one per **job**, not one per pay stub. Now labeled "Job 1..6", the amount field reads "Gross wages, salary, and commissions (per month)", and the screen says outright that the figure is monthly, with a conversion table (weekly x4.33, biweekly x2.17, semimonthly x2).

> "I am a bit unsure how that played out in the means test."

That surfaced a real bug. Form 122A and the Form 103B fee waiver pre-filled income from **slot 1 only**, so anyone with a second job saw a means-test figure that silently disagreed with their own Schedule I. Form 101 summed the slots but dropped `overtime_pay_4` through `6`. All three now go through one helper, `gross_monthly_wages()` in `objects.py`.

## 2. Only Form 101 appeared to arrive

> "it looks like only the first 9 pages are there. Only Form 101 but none of the Schedules or anything else."

The conclusion emails every document as its own attachment. `b_101.pdf` is exactly nine pages and sorts first, so opening the first of ~20 attachments looks like the rest never came. The conclusion now also assembles every form into a single `bankruptcy_petition_packet.pdf` and offers it **first**, and the conclusion copy explains that the emailed forms arrive separately.

## 3. The Reset button on the emailed PDF wiped the form

> "the pdf that was emailed to me has a 'Reset' button at the bottom. I pushed it just to see if it would work. It does. It deleted everything."

20 of the 27 official USCourts B-form templates ship a `/ResetForm` pushbutton, and nothing set `editable:` on the attachments, so every assembled form went out as a live fillable form with a working wipe-everything button. All 23 attachments across 19 question files now set `editable: pdf_editable`, which resolves through pdftk `flatten` to stamped, non-interactive pages. Measured on `b_101.pdf`: **478 fields + 1 ResetForm action before, 0 and 0 after.**

Flattening removes the AcroForm the field-reading specs assert against, so `?pdf_editable=1` opts back into fillable output. Tests use it via `INTERVIEW_URL`; real users never pass it. New `pdf-flattening.spec.ts` drives `PRODUCTION_INTERVIEW_URL` and asserts zero form fields on every delivered PDF plus a packet whose page count equals the sum of the individual forms (65 = 65), and separately guards that the escape hatch still yields fillable output so those specs cannot silently start asserting against empty field maps.

Also fixed: `downloadAllPdfs()` paired headings to download links by index after keeping only headings starting with "Form", which mislabels every PDF once the packet joins the list. It now walks the DOM in order.

## Verification

- 21/21 on `pdf-field-population`, `pdf-verification`, `income-review-edit`, `means-test-nonfiling-spouse`, `means-test-social-security`, `fee-waiver-poverty-line`
- Both `pdf-flattening` tests
- All 8 static gates (`npm run lint`) clean

No legal citations or statutory dollar amounts were touched; the wording changes are plain-English UX copy.

Note: comments in `voluntary-petition.yml:356` and `pdf-flattening.spec.ts:10` say "21 of the 27" templates ship the Reset button. The measured number is 20.
