### PR TITLE
Fix final Roxanne and William UAT issues

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/106Dec-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/106Dec-question-blocks.yml
@@ -34,10 +34,10 @@ code: |
   # Execution date
   declaration_fields['Executed on'] = format_date(today(), format='MM/dd/yyyy')
 
-  # Signature fields (debtor typed names as signature placeholders)
-  declaration_fields['Debtor1.signature'] = '/s/ ' + _d1_name
-  declaration_fields['Debtor 1'] = '/s/ ' + _d1_name
-  declaration_fields['Debtor 2'] = '/s/ ' + _d2_name if _d2_name else ''
+  # Debtors must sign the filed declaration themselves. Do not preprint an
+  # electronic /s/ signature from the typed name gathered by the interview.
+  declaration_fields['Debtor1.signature'] = ''
+  declaration_fields['Debtor2.signature'] = ''
 
   # Name of person paid to help (bankruptcy petition preparer, if any)
   declaration_fields['Name of person payed to help file'] = ''

--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -4,18 +4,17 @@ from docassemble.base.util import DAObject, Individual
 SOUTH_DAKOTA_EXEMPTIONS = {
     'homestead': 'Homestead (SDCL 43-31-1 – 43-31-6)',
     'homestead_proceeds': 'Homestead, proceeds of sale (SDCL 43-31-4)',
-    'household_goods': 'Furniture and bedding (SDCL 43-45-5(5))',
     'wildcard': 'Wildcard (SDCL 43-45-4)',
     'personal_property': 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)',
     'domestic_support': 'Alimony, maintenance, or support of the debtor (SDCL 43-45-2)',
     'health_aids': 'Health aids (SDCL 43-45-2)',
-    'tools': 'Tools of the trade (SDCL 43-45-5(6))',
+    'tools': 'Tools of the trade (SDCL 43-45-6)',
     'city_employee_pensions': 'City employee pensions (SDCL 9-16-47)',
     'public_employee_pensions': 'Public employee pensions (SDCL 3-12-115)',
     'retirement': 'Retirement (SDCL 43-45-16)',
     'public_assistance': 'Public assistance (SDCL 28-7-16)',
     'wages': 'Wages (SDCL 15-20-12)',
-    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)',
+    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4)',
     'workers_comp': 'Workers compensation (SDCL 62-4-42)',
     'unemployment': 'Unemployment (SDCL 61-6-28)',
     'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
@@ -380,7 +379,6 @@ def get_exemption_limits(user_state, head_of_family=False):
         return {
             'homestead': 0,          # Unlimited
             'homestead_proceeds': 0,  # Unlimited
-            'household_goods': 0,     # Unlimited (SD doesn't specify a dollar limit on furniture/bedding)
             'wildcard': 7000 if head_of_family else 5000,  # SDCL 43-45-4 (William Franck, ERLS, June 2026)
             'personal_property': 0,   # Unlimited
             'health_aids': 0,         # Unlimited

--- a/tests/test_august_2026_final_uat.py
+++ b/tests/test_august_2026_final_uat.py
@@ -1,0 +1,36 @@
+"""Regression coverage for Roxanne and William's final August 2026 UAT."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OBJECTS = (ROOT / 'docassemble/BankruptcyClinic/objects.py').read_text()
+
+
+def test_south_dakota_repealed_furniture_exemption_is_not_offered():
+    south_dakota_block = OBJECTS.split('SOUTH_DAKOTA_EXEMPTIONS = {', 1)[1].split(
+        'NEBRASKA_EXEMPTIONS = {', 1
+    )[0]
+    south_dakota_limits = OBJECTS.split("if 'south dakota' in state_str:", 1)[1].split(
+        'else:', 1
+    )[0]
+    assert "'household_goods'" not in south_dakota_block
+    assert "'household_goods'" not in south_dakota_limits
+
+
+def test_south_dakota_tools_and_life_insurance_citations_are_distinct():
+    assert "'tools': 'Tools of the trade (SDCL 43-45-6)'" in OBJECTS
+    assert "'life_insurance': 'Life insurance proceeds (SDCL 58-12-4)'" in OBJECTS
+
+
+def test_declaration_does_not_preprint_debtor_signatures():
+    source = (ROOT / 'docassemble/BankruptcyClinic/data/questions/106Dec-question-blocks.yml').read_text()
+    assert "declaration_fields['Debtor1.signature'] = ''" in source
+    assert "declaration_fields['Debtor2.signature'] = ''" in source
+    assert "'/s/ '" not in source
+
+
+if __name__ == '__main__':
+    test_south_dakota_repealed_furniture_exemption_is_not_offered()
+    test_south_dakota_tools_and_life_insurance_citations_are_distinct()
+    test_declaration_does_not_preprint_debtor_signatures()
+    print('OK: all August 2026 final-UAT regression tests passed')


### PR DESCRIPTION
## Summary
- leave both debtor signature fields blank on Form B106Dec so the generated declaration does not preprint an `/s/` signature
- remove the repealed SDCL 43-45-5(5) furniture and bedding exemption from South Dakota choices and limits
- cite SDCL 43-45-6 for tools of the trade and keep life-insurance proceeds under SDCL 58-12-4
- add focused regression coverage for all three corrections

## Verification
- `python3 tests/test_august_2026_final_uat.py`
- `python3 -m py_compile docassemble/BankruptcyClinic/objects.py tests/test_august_2026_final_uat.py`
- `git diff --check -- docassemble/BankruptcyClinic/objects.py docassemble/BankruptcyClinic/data/questions/106Dec-question-blocks.yml tests/test_august_2026_final_uat.py`
- inspected Form B106Dec AcroForm field names with `pdftk` to confirm `Debtor1.signature` and `Debtor2.signature` are the signature fields