### PR TITLE
Remove nonexistent South Dakota tools exemption

### DIFF
--- a/docassemble/BankruptcyClinic/objects.py
+++ b/docassemble/BankruptcyClinic/objects.py
@@ -8,13 +8,12 @@ SOUTH_DAKOTA_EXEMPTIONS = {
     'personal_property': 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)',
     'domestic_support': 'Alimony, maintenance, or support of the debtor (SDCL 43-45-2)',
     'health_aids': 'Health aids (SDCL 43-45-2)',
-    'tools': 'Tools of the trade (SDCL 43-45-6)',
     'city_employee_pensions': 'City employee pensions (SDCL 9-16-47)',
     'public_employee_pensions': 'Public employee pensions (SDCL 3-12-115)',
     'retirement': 'Retirement (SDCL 43-45-16)',
     'public_assistance': 'Public assistance (SDCL 28-7-16)',
     'wages': 'Wages (SDCL 15-20-12)',
-    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4)',
+    'life_insurance': 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)',
     'workers_comp': 'Workers compensation (SDCL 62-4-42)',
     'unemployment': 'Unemployment (SDCL 61-6-28)',
     'student_loan': 'Student loan (20 U.S.C. § 1095a(d))',
@@ -382,7 +381,6 @@ def get_exemption_limits(user_state, head_of_family=False):
             'wildcard': 7000 if head_of_family else 5000,  # SDCL 43-45-4 (William Franck, ERLS, June 2026)
             'personal_property': 0,   # Unlimited
             'health_aids': 0,         # Unlimited
-            'tools': 0,              # Unlimited
             'retirement': 1000000,    # SDCL 43-45-16: $1,000,000 cap on
                                       # employee benefit plans (William Franck,
                                       # ERLS, June 2026). Prior cite 43-45-26

--- a/tests/test_august_2026_final_uat.py
+++ b/tests/test_august_2026_final_uat.py
@@ -17,9 +17,16 @@ def test_south_dakota_repealed_furniture_exemption_is_not_offered():
     assert "'household_goods'" not in south_dakota_limits
 
 
-def test_south_dakota_tools_and_life_insurance_citations_are_distinct():
-    assert "'tools': 'Tools of the trade (SDCL 43-45-6)'" in OBJECTS
-    assert "'life_insurance': 'Life insurance proceeds (SDCL 58-12-4)'" in OBJECTS
+def test_south_dakota_has_no_tools_exemption_and_both_life_insurance_citations():
+    south_dakota_block = OBJECTS.split('SOUTH_DAKOTA_EXEMPTIONS = {', 1)[1].split(
+        'NEBRASKA_EXEMPTIONS = {', 1
+    )[0]
+    south_dakota_limits = OBJECTS.split("if 'south dakota' in state_str:", 1)[1].split(
+        'else:', 1
+    )[0]
+    assert "'tools'" not in south_dakota_block
+    assert "'tools'" not in south_dakota_limits
+    assert "'life_insurance': 'Life insurance proceeds (SDCL 58-12-4, 43-45-6)'" in OBJECTS
 
 
 def test_declaration_does_not_preprint_debtor_signatures():
@@ -31,6 +38,6 @@ def test_declaration_does_not_preprint_debtor_signatures():
 
 if __name__ == '__main__':
     test_south_dakota_repealed_furniture_exemption_is_not_offered()
-    test_south_dakota_tools_and_life_insurance_citations_are_distinct()
+    test_south_dakota_has_no_tools_exemption_and_both_life_insurance_citations()
     test_declaration_does_not_preprint_debtor_signatures()
     print('OK: all August 2026 final-UAT regression tests passed')


### PR DESCRIPTION
## Summary
- remove tools of the trade from South Dakota exemption choices and limits
- restore SDCL 43-45-6 alongside SDCL 58-12-4 on the life-insurance proceeds entry
- update the final-UAT regression test for William's clarification

## Verification
- `python3 tests/test_august_2026_final_uat.py`
- `python3 -m py_compile docassemble/BankruptcyClinic/objects.py tests/test_august_2026_final_uat.py`
- targeted `git diff --check`