### PR TITLE
Fix issue #145 test failures and make the Playwright workflow runnable

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,11 +4,15 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:
-  test:
-    timeout-minutes: 60
+  static-gates:
+    # The eight burn-down gates (selectors, yaml-ids, flow, test-completeness,
+    # caps-sync, pdf-fields, namespace-clobber, seek-sim) are pure static
+    # analysis — no docassemble server needed, so they run on every push/PR.
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -20,15 +24,30 @@ jobs:
     - name: Interview flow gates (static — no server needed)
       run: |
         chmod +x scripts/*.sh
-        ./scripts/lint-flow-gaps.sh
-        ./scripts/lint-test-completeness.sh
-        python3 scripts/lint_caps_sync.py
-        ./scripts/lint-pdf-fields.sh   # builder keys must exist in the PDF templates (needs pdf-lib from npm ci)
+        npm run lint
+  browser-suite:
+    # The Playwright suite drives a REAL docassemble server; GitHub-hosted
+    # runners have none, which is why every historical run of this workflow
+    # failed. The job runs only when a reachable server URL is configured as
+    # the DA_SERVER_URL repository variable (Settings > Secrets and variables
+    # > Actions > Variables). Until then it is skipped, and the local
+    # container pool (npm run test:pool — see CLAUDE.md) remains the
+    # browser-suite gate.
+    if: ${{ vars.DA_SERVER_URL != '' }}
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx playwright install --with-deps chromium
     - name: Run Playwright tests
-      run: npx playwright test --project=chromium --workers=1
-      timeout-minutes: 30
+      run: BASE_URL="${{ vars.DA_SERVER_URL }}" npx playwright test --project=chromium --workers=1
+      timeout-minutes: 50
     - uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:

--- a/tests/roxanne-feedback-fixes.spec.ts
+++ b/tests/roxanne-feedback-fixes.spec.ts
@@ -83,6 +83,14 @@ test.describe('Roxanne feedback fixes', () => {
     await navigatePropertySection(page, SIMPLE_SINGLE);
     await waitForDaPageLoad(page);
 
+    // Schedule C now opens with the 730-day domicile screen (PR #132), which
+    // replaced the exemption-type question as the first page. Verify the old
+    // question isn't on it either, then answer Yes to move past it.
+    const domicilePage = await page.locator('body').innerText();
+    expect(domicilePage).not.toContain('Which set of exemptions');
+    await clickYesNoButton(page, 'prop.domicile_two_years', true);
+    await waitForDaPageLoad(page);
+
     // The "Which set of exemptions are you claiming?" question is no longer
     // asked — Phil/Roxanne feedback found that NE/SD filers in these districts
     // must claim the state exemption set anyway, so the old prompt only

--- a/tests/sd-head-of-family-wildcard.spec.ts
+++ b/tests/sd-head-of-family-wildcard.spec.ts
@@ -55,8 +55,12 @@ test('SD filer is asked the head-of-family question for the SDCL 43-45-4 wildcar
   await passDebtorFinal(page);
   await navigatePropertySection(page, SD_SINGLE);
 
-  // The head-of-family question appears at the start of the exemption section
-  // for a South Dakota filer.
+  // The exemption section now opens with the 730-day domicile screen (PR #132).
+  // Answer Yes (lived in SD 2+ years) to reach the head-of-family question.
+  await waitForDaPageLoad(page);
+  await clickYesNoButton(page, 'prop.domicile_two_years', true);
+
+  // The head-of-family question follows for a South Dakota filer.
   await waitForDaPageLoad(page);
   const heading = ((await page.locator('h1').first().textContent()) || '').toLowerCase();
   expect(heading).toContain('head of a family');

--- a/tests/walker-helpers.ts
+++ b/tests/walker-helpers.ts
@@ -196,9 +196,26 @@ export async function fillVisibleRequiredFields(
       const base = cb.id.replace(/_\d+$/, '');   // choice index -> group base
       (groups.get(base) || groups.set(base, []).get(base)!).push(cb);
     }
+    // A visible validation error alongside an already-checked group means the
+    // server rejected the current COMBINATION (e.g. the creditor library's
+    // "same creditor in both lists" rule) — the page re-renders with the bad
+    // boxes still checked, so "skip groups with a checked member" resubmits
+    // the same rejected state forever (fuzz seed 71077345 burned all 800
+    // steps this way). A real user unchecks a box; do the same: clear the
+    // group and let the damped re-pick below choose again ("None of the
+    // above" once yesBias decays to 0, which always satisfies the rule).
+    const pageHasError = Array.from(
+      document.querySelectorAll('.invalid-feedback, .da-has-error, .alert-danger, label.error')
+    ).some((e) => (e as HTMLElement).offsetParent !== null && !!e.textContent?.trim());
     for (const members of groups.values()) {
       // Only real choice groups (>=2 members); skip lone yesno checkboxes.
-      if (members.length < 2 || members.some((c) => c.checked)) continue;
+      if (members.length < 2) continue;
+      if (members.some((c) => c.checked)) {
+        if (!pageHasError) continue;
+        for (const c of members) {
+          if (c.checked) (document.querySelector(`label[for="${CSS.escape(c.id)}"]`) as HTMLElement).click();
+        }
+      }
       const labelOf = (c: HTMLInputElement) =>
         (document.querySelector(`label[for="${CSS.escape(c.id)}"]`)?.textContent || '');
       const nota = members.find((c) => /none of the above/i.test(labelOf(c)));


### PR DESCRIPTION
Closes #145.

## What the four failures actually were

Three of the four were **stale tests**, one was a **test-harness bug**. No product bug.

| Spec | Verdict |
|---|---|
| `sd-head-of-family-wildcard` | Stale — PR #132 made the 730-day domicile question the first exemption screen |
| `roxanne-feedback-fixes` (relabel) | Stale — same cause |
| `maximalist` | Already fixed on main by #156; verified green serially |
| `fuzz-walker` seed 71077345 | Test-harness bug in the walker, detailed below |

### The fuzz seed

The walker checked the same creditor in **both** creditor-library lists ("owe money to" and "notify only"). The interview correctly rejects that combination with a validation message. But `fillVisibleRequiredFields` skipped any checkbox group that already had a checked member, so the walker resubmitted the identical rejected state until it burned all 800 steps and reported "never reached the conclusion."

The walker now clears an already-checked group when a visible validation error is present and re-picks. Yes-bias damping then lands on "None of the above," which always satisfies the rule — the same recovery a real user performs. The seed reaches the conclusion in 107 steps.

## Why the workflow could never pass

Separate from #145: the job ran the full browser suite on GitHub-hosted runners, which have no docassemble server. **Every run in the workflow's history failed for that reason** — disabling it was not only about #145, and re-enabling it unchanged would have gone straight back to red.

It now always runs the eight static gates (`npm run lint` — all pure static analysis, no server needed), and runs the browser suite only when a `DA_SERVER_URL` repository variable points at a reachable server. Until that variable exists, the local container pool (`npm run test:pool`) remains the browser gate, as documented in CLAUDE.md.

The "ALKiln v5 tests" workflow has nothing to re-enable: its file was deliberately removed in e368e39; only the disabled registration lingers in the Actions UI.

## Verification

- Both fixed specs green serially against a deployed container
- `maximalist` green serially (5.4m)
- Fuzz seed 71077345 green (1.8m, 107 steps to conclusion)
- All 8 static gates pass — which is exactly what the new `static-gates` job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)