### PR TITLE
Remove the post-conclusion Exit screen that acted as a reset button

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
+++ b/docassemble/BankruptcyClinic/data/questions/101-question-blocks.yml
@@ -1423,7 +1423,13 @@ subquestion: |
 allow downloading: True
 attachment code: |
   conclusion_attachments
-continue button field: conclusion_screen
+# Terminal screen: `event` (not `continue button field`) so there is no
+# button past this point. The old flow continued to an "Interview questions
+# complete!" screen whose only control was Exit — docassemble's Exit deletes
+# the session's answers, so it acted as a reset button and wiped a filer's
+# completed interview (client-reported). The interview now ends here, with
+# the downloads.
+event: conclusion_screen
 section: fin
 ---
 code: |

--- a/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
+++ b/docassemble/BankruptcyClinic/data/questions/voluntary-petition.yml
@@ -1079,13 +1079,6 @@ code: |
   print_101
   conclusion_screen
 ---
-question: |
-  Interview questions complete!
-buttons:
-  - Exit
-section: fin
-mandatory: True
----
 code: |
   debtor[i].name.first
   debtor[i].name.last


### PR DESCRIPTION
Client-requested (Legal Aid of Nebraska, via WP-04).

## The reset button

The pro se flow ended one screen *past* the conclusion, on an "Interview questions complete!" screen whose only control was an **Exit** button. docassemble's Exit deletes the session's answers — so a filer who clicked the only button on the final screen wiped their completed interview. That is a reset button in effect, and it sat directly after the screen where people are told to download their forms.

(The other reset in this class — the `/ResetForm` pushbutton inside 20 of the 27 official B-form PDF templates — was already neutralized by PDF flattening in #155.)

## The change

The conclusion screen (downloads, creditor matrix, after-you-file instructions) becomes the interview's terminal screen:

- `continue button field: conclusion_screen` → `event: conclusion_screen` in `101-question-blocks.yml`, so there is no button past it
- the Exit-only mandatory screen is deleted from `voluntary-petition.yml`

Nothing else reads `conclusion_screen`, and the specs use "interview questions complete" only as one alternative in their reached-the-end assertions, so they stay green either way.

## Verification

- All 8 static gates pass, including the path-sensitive seek simulator (no dead ends or seek loops introduced)
- Deployed to a local container and driven end to end through PDF assembly

🤖 Generated with [Claude Code](https://claude.com/claude-code)