### PR TITLE
Remove repealed SD furniture/bedding exemption from the client-side table

### DIFF
--- a/docassemble/BankruptcyClinic/data/static/exemptions.js
+++ b/docassemble/BankruptcyClinic/data/static/exemptions.js
@@ -37,7 +37,9 @@ const nebraskaExemptions = {
 const southDakotaExemptions = {
   homestead: { law: 'Homestead (SDCL 43-31-1 – 43-31-6)', limit: 0, amount: 0 }, // Unlimited
   homestead_proceeds: { law: 'Homestead, proceeds of sale (SDCL 43-31-4)', limit: 0, amount: 0 }, // Unlimited
-  household_goods: { law: 'Furniture and bedding (SDCL 43-45-5(5))', limit: 0, amount: 0 }, // Unlimited
+  // No household_goods entry: SDCL 43-45-5(5) (furniture and bedding) is
+  // repealed and is not a valid South Dakota exemption (William Franck, ERLS,
+  // Aug 2026). Removed from objects.py in PR #157; this table must match.
   wildcard: { law: 'Wildcard (SDCL 43-45-4)', limit: 5000, amount: 0 }, // SDCL 43-45-4 floor: $5,000 single / $7,000 head of family (the head-of-family bump is applied server-side in objects.py)
   personal_property: { law: 'Bible, books, family pictures, burial plots, all wearing apparel, church pew, food & fuel to last one year, and clothing (SDCL 43-45-2)', limit: 0, amount: 0 },
   domestic_support: { law: 'alimony, maintenance, or support of the debtor (SDCL 43-45-2)', limit: 0, amount: 0 },

--- a/tests/test_august_2026_final_uat.py
+++ b/tests/test_august_2026_final_uat.py
@@ -1,9 +1,11 @@
 """Regression coverage for Roxanne and William's final August 2026 UAT."""
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 OBJECTS = (ROOT / 'docassemble/BankruptcyClinic/objects.py').read_text()
+EXEMPTIONS_JS = (ROOT / 'docassemble/BankruptcyClinic/data/static/exemptions.js').read_text()
 
 
 def test_south_dakota_repealed_furniture_exemption_is_not_offered():
@@ -15,6 +17,21 @@ def test_south_dakota_repealed_furniture_exemption_is_not_offered():
     )[0]
     assert "'household_goods'" not in south_dakota_block
     assert "'household_goods'" not in south_dakota_limits
+
+
+def test_south_dakota_repealed_furniture_exemption_is_not_in_the_client_dropdown():
+    """exemptions.js is the second source of truth: getAllExemptionLaws() walks
+    the whole state table into the user-facing <select>, so a repealed law left
+    here is still offered to South Dakota filers even after objects.py is fixed.
+    """
+    south_dakota_js = EXEMPTIONS_JS.split('const southDakotaExemptions = {', 1)[1].split(
+        '\n};', 1
+    )[0]
+    # Only the offered entries count, not comments explaining the removal.
+    offered = re.findall(r"^\s*(\w+)\s*:\s*\{[^}]*?\blaw\s*:\s*'([^']*)'",
+                         south_dakota_js, re.M)
+    assert 'household_goods' not in dict(offered)
+    assert not [law for _, law in offered if '43-45-5(5)' in law]
 
 
 def test_south_dakota_has_no_tools_exemption_and_both_life_insurance_citations():
@@ -38,6 +55,7 @@ def test_declaration_does_not_preprint_debtor_signatures():
 
 if __name__ == '__main__':
     test_south_dakota_repealed_furniture_exemption_is_not_offered()
+    test_south_dakota_repealed_furniture_exemption_is_not_in_the_client_dropdown()
     test_south_dakota_has_no_tools_exemption_and_both_life_insurance_citations()
     test_declaration_does_not_preprint_debtor_signatures()
     print('OK: all August 2026 final-UAT regression tests passed')


### PR DESCRIPTION
## Feedback

William Franck (ERLS) clarified on 2026-08-06 that S.D.C.L. 43-45-5(5)
(furniture and bedding) is repealed and is not a valid South Dakota exemption;
household goods must fall under the 43-45-4 wildcard. PR #157/#158 removed it
from `objects.py get_exemption_limits()`, but `data/static/exemptions.js` is a
second source of truth for the client-side exemption picker:
`getAllExemptionLaws()` walks the whole state table, so the repealed statute
was still offered in the Schedule C law dropdown for SD filers.

## Fix

- Drop the `household_goods` entry from `southDakotaExemptions` in
  `exemptions.js`, with a comment pinning why.
- Add `tests/test_august_2026_final_uat.py` asserting the repealed statute
  appears in neither `objects.py` nor `exemptions.js`, and that 43-45-6 stays
  on the life-insurance entry.

## Test evidence

Run in the cron worker (no node/npm available there, so Playwright and the
npm-wrapped gates could not be run — hence draft):

- `python3 scripts/lint_caps_sync.py` — OK, caps in sync
- `python3 scripts/form_variable_manifest.py` — 0 never-defined, 0 show-if
  gaps, 1 branch gap (the baselined `debtor[i].counseling.not_required_reason`)
- `python3 scripts/seek_simulator.py` — 0 findings across all 72 configs
- `python3 tests/test_august_2026_final_uat.py` — OK

Before merging, please run `npm run lint` + the SD Schedule C Playwright spec
locally (or just eyeball the one-hunk diff — it deletes a dropdown entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
