### PR TITLE
Enable live help chat with bankruptcy partner role

### DIFF
--- a/docassemble/BankruptcyClinic/data/questions/mandatory-initial-code.yml
+++ b/docassemble/BankruptcyClinic/data/questions/mandatory-initial-code.yml
@@ -2,3 +2,18 @@ mandatory: True
 code: |
   menu_items = [ action_menu_item('Review Answers', 'review_answers') ]
 ---
+# Live help / chat. `initial` (not `mandatory`) so availability re-evaluates on
+# every screen load as operators sign in and out of /monitor. Operators must
+# have the admin or advocate privilege and check the "bankruptcy" role on the
+# Monitor page to see these sessions; other interviews on the server are
+# unaffected because they never call set_live_help_status().
+initial: True
+code: |
+  if chat_partners_available('bankruptcy').help > 0:
+    set_live_help_status(availability='available',
+                         mode='help',
+                         partner_roles=['bankruptcy'])
+  else:
+    set_live_help_status(availability='observeonly',
+                         partner_roles=['bankruptcy'])
+---


### PR DESCRIPTION
Turns on docassemble live help for the bankruptcy interview only, per the plan Alex approved.

- New `initial: True` code block in `mandatory-initial-code.yml` (already included by `voluntary-petition.yml`).
- When an operator covering the **bankruptcy** partner role is available on /monitor: `availability='available'`, `mode='help'` (private user↔operator chat).
- Otherwise `observeonly`: no chat box shown, but staff can still watch/take over sessions.
- `initial` (not `mandatory`) so the status re-evaluates on every screen load as operators sign in/out.
- `laonwalkin` and other interviews are unaffected — live help is opt-in per interview and nothing else calls `set_live_help_status()`.
- No Twilio / phone forwarding in this pass.

Server-side prerequisites (config, handled separately): `url root` and `external hostname` must be the real https URL and `behind https load balancer: true`, or the chat websocket will not connect.

Verified: YAML parses; `lint:flow` and `lint:seek-sim` gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGn7rrKyZbdZsAqgJs5DG9